### PR TITLE
fix(harvest): tolerate a shortfall too small to be anything but registry noise

### DIFF
--- a/registry/scripts/src/build.ts
+++ b/registry/scripts/src/build.ts
@@ -20,7 +20,7 @@ import { fetchStarCounts } from './github-stars.ts'
 import { harvestRepos } from './github-client.ts'
 import { parseRepoState, serializeRepoState } from './repo-state.ts'
 import { githubOwnerName } from './github-repo.ts'
-import { fetchCandidates, searchByKeywords } from './npm-client.ts'
+import { fetchCandidates, searchByKeywords, type KeywordShortfall } from './npm-client.ts'
 import { runPipeline } from './pipeline.ts'
 import { CATALOG_SCHEMA_VERSION, SCHEMA_VERSION, SUBPACKAGE_SCHEMA_VERSION } from './emit.ts'
 import { assembleStarsByKey } from './stars-assemble.ts'
@@ -80,6 +80,8 @@ if (basename(process.argv[1] ?? '') === 'build.ts') {
   const config = loadRegistryConfig(REGISTRY_DIR)
   let candidates: Candidate[]
   let rejections: Rejection[]
+  /** Tolerated npm search shortfalls, for the published report. */
+  let npmNote = ''
   if (harvestFrom === undefined) {
     // registry.npmmirror.com does not implement the `keywords:` qualifier this
     // search depends on — measured 2026-09-03, it answers
@@ -89,18 +91,34 @@ if (basename(process.argv[1] ?? '') === 'build.ts') {
     // a stalled or 5xx npmjs search would publish a zero-name harvest with a
     // green build rather than failing loud. The search below therefore takes
     // no backup argument; classify.ts's harvest call carries the same fix.
-    const names = await searchByKeywords(fetch, undefined, npmToken)
+    // A shortfall inside MAX_SEARCH_SHORTFALL does not stop the harvest, but it
+    // does mean this build is missing that many packages, and nothing here can
+    // name them. Collected so the published report says so — the count is the
+    // only honest thing available.
+    const shortfalls: KeywordShortfall[] = []
+    const names = await searchByKeywords(fetch, undefined, npmToken, undefined, undefined, s => shortfalls.push(s))
+    for (const s of shortfalls) {
+      npmNote += `${npmNote === '' ? '' : '; '}keywords:${s.keyword} enumerated ${s.enumerated} of ${s.required}`
+      process.stderr.write(`npm: keywords:${s.keyword} enumerated ${s.enumerated} of ${s.required} names, within the tolerated shortfall\n`)
+    }
     process.stderr.write(`harvested ${names.length} npm candidate(s)\n`)
     const harvested = await fetchCandidates(names, fetch, npmToken, npmBackupRegistry)
     candidates = harvested.candidates
     rejections = harvested.rejections
   } else {
-    const parsed = JSON.parse(readFileSync(harvestFrom, 'utf8')) as { candidates?: unknown; rejections?: unknown }
+    const parsed = JSON.parse(readFileSync(harvestFrom, 'utf8')) as {
+      candidates?: unknown; rejections?: unknown; shortfalls?: unknown
+    }
     if (!Array.isArray(parsed.candidates) || !Array.isArray(parsed.rejections)) {
       throw new Error(`--harvest-from ${harvestFrom}: expected { candidates, rejections } arrays`)
     }
     candidates = parsed.candidates as Candidate[]
     rejections = parsed.rejections as Rejection[]
+    // Optional: a handoff written before this field existed simply carries
+    // none, and an older build reading a newer handoff ignores it.
+    for (const s of Array.isArray(parsed.shortfalls) ? parsed.shortfalls as KeywordShortfall[] : []) {
+      npmNote += `${npmNote === '' ? '' : '; '}keywords:${s.keyword} enumerated ${s.enumerated} of ${s.required}`
+    }
     process.stderr.write(`reusing harvest: ${candidates.length} npm candidate(s)\n`)
   }
 
@@ -269,8 +287,9 @@ if (basename(process.argv[1] ?? '') === 'build.ts') {
   writeFileSync(join(OUT_DIR, 'badge.json'), artifacts.badgeJson)
   writeFileSync(join(REGISTRY_DIR, 'snapshots/manifest.lock'), artifacts.manifestLock)
   writeFileSync(join(REGISTRY_DIR, 'first-seen.yml'), serializeFirstSeen(firstSeen))
+  const npmLine = npmNote === '' ? '' : `\nnpm search shortfall (tolerated, packages missing from this build): ${npmNote}\n`
   const repoLine = repoNote === '' ? '' : `\nGitHub: ${repoNote}\n`
-  writeFileSync(join(OUT_DIR, 'report.md'), `${artifacts.report}\nStars: ${starsNote}\n${repoLine}`)
+  writeFileSync(join(OUT_DIR, 'report.md'), `${artifacts.report}\nStars: ${starsNote}\n${npmLine}${repoLine}`)
 
   process.stderr.write(`wrote ${OUT_DIR}/${artifacts.pluginsFileName}\n`)
 }

--- a/registry/scripts/src/classify.ts
+++ b/registry/scripts/src/classify.ts
@@ -23,7 +23,7 @@ import { classifyPackages } from './llm-client.ts'
 import { judgeMarkets, type MarketItem } from './market-judge.ts'
 import { selectMarketPending } from './market-select.ts'
 import { mergeMarketRows, serializeMarketRows } from './markets.ts'
-import { fetchCandidates, searchByKeywords } from './npm-client.ts'
+import { fetchCandidates, searchByKeywords, type KeywordShortfall } from './npm-client.ts'
 import { parseRepoState } from './repo-state.ts'
 import type { Category, RepoCandidate } from './types.ts'
 
@@ -80,7 +80,16 @@ if (basename(process.argv[1] ?? '') === 'classify.ts') {
   const npmBackupRegistry = rawBackupRegistry ?? 'https://registry.npmmirror.com'
 
   const config = loadRegistryConfig(REGISTRY_DIR)
-  const names = await searchByKeywords(fetch, undefined, npmToken)
+  // A shortfall inside MAX_SEARCH_SHORTFALL publishes rather than stopping the
+  // build, but it means this harvest is missing that many packages. It is
+  // collected here rather than only in build.ts because CI reuses THIS harvest
+  // (`--harvest-from`), so build.ts's own search never runs there — and this is
+  // the call that actually died on `3746 of 3747` on 2026-09-04.
+  const shortfalls: KeywordShortfall[] = []
+  const names = await searchByKeywords(fetch, undefined, npmToken, undefined, undefined, s => shortfalls.push(s))
+  for (const s of shortfalls) {
+    process.stderr.write(`classify: keywords:${s.keyword} enumerated ${s.enumerated} of ${s.required} names, within the tolerated shortfall\n`)
+  }
   process.stderr.write(`classify: harvested ${names.length} candidate(s)\n`)
   const { candidates, rejections } = await fetchCandidates(names, fetch, npmToken, npmBackupRegistry)
 
@@ -159,7 +168,7 @@ if (basename(process.argv[1] ?? '') === 'classify.ts') {
   mkdirSync(OUT_DIR, { recursive: true })
   mkdirSync(join(REGISTRY_DIR), { recursive: true })
   writeFileSync(join(REGISTRY_DIR, 'categories.yml'), serializeCategoryRows(merged))
-  writeFileSync(join(OUT_DIR, 'harvest.json'), `${JSON.stringify({ candidates, rejections })}\n`)
+  writeFileSync(join(OUT_DIR, 'harvest.json'), `${JSON.stringify({ candidates, rejections, shortfalls })}\n`)
   const sortedDiscards = [...discarded].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
   const reportLines = [
     '# Classification report',

--- a/registry/scripts/src/npm-client.ts
+++ b/registry/scripts/src/npm-client.ts
@@ -31,6 +31,41 @@ export const MAX_SEARCH_FROM = 5000
 export const SEARCH_WINDOW = MAX_SEARCH_FROM + PAGE_SIZE
 
 /**
+ * The largest per-keyword shortfall the harvest publishes through rather than
+ * refusing.
+ *
+ * The coverage check below already absorbs churn two ways — `Math.min` of the
+ * totals probed before and after, and one full re-page — and neither can close
+ * the case this bound exists for: npm answering a `total` it cannot serve. On
+ * 2026-09-04 `main`'s daily build died on `enumerated 3746 of 3747`, one name,
+ * with both probes answering 3747 and the second pass finding the same 3746.
+ * This module's own comment names the mechanism ("Same for a `total` npm
+ * overstates by one"), so it is a shortfall no amount of re-reading closes. The
+ * scheduled run that hour had passed and the push run failed, which makes it a
+ * coin flip per run, and a lost flip freezes the shelf for the day.
+ *
+ * Why 3, and not a rounder number: two magnitudes for a REAL gap are recorded
+ * in this file. A partition gap is "hundreds of names", and PARTITION_KEYWORDS
+ * was measured FIFTEEN names short the day after it was documented as
+ * complete. A bound at or above 15 would have absorbed that one silently. 3
+ * covers what it is for — an overstated total, a page serving 249 objects of
+ * 250 — and stops well short of anything this repo has seen go genuinely
+ * wrong.
+ *
+ * A tolerated shortfall is never silent: {@link searchByKeywords} reports it to
+ * its caller, because nothing here can name the missing package — that is the
+ * whole difficulty — so the count is the honest thing to publish.
+ */
+export const MAX_SEARCH_SHORTFALL = 3
+
+/** One keyword that enumerated fewer names than its own total promised. */
+export interface KeywordShortfall {
+  keyword: string
+  enumerated: number
+  required: number
+}
+
+/**
  * Refinement keywords the harvest ANDs onto an over-window keyword to split it
  * into reachable cells, most-covering first.
  *
@@ -732,6 +767,7 @@ export async function searchByKeywords(
   token: string | undefined = undefined,
   backupRegistry: string | undefined = undefined,
   timeoutMs: number = REQUEST_TIMEOUT_MS,
+  onShortfall: (shortfall: KeywordShortfall) => void = () => {},
 ): Promise<string[]> {
   const seen = new Set<string>()
   const probe = (keywords: readonly string[]): Promise<number> =>
@@ -840,7 +876,13 @@ export async function searchByKeywords(
       await enumerate()
       required = Math.min(required, await probe([keyword]))
     }
-    if (forKeyword.size < required) {
+    const shortfall = required - forKeyword.size
+    if (shortfall > 0 && shortfall <= MAX_SEARCH_SHORTFALL) {
+      // Small enough to be the registry answering a total it cannot serve.
+      // Reported, never swallowed: the caller puts it in the build report, and
+      // a bound this low cannot hide any gap this repo has seen.
+      onShortfall({ keyword, enumerated: forKeyword.size, required })
+    } else if (shortfall > 0) {
       throw new Error(partitioned
         ? `npm search for ${keywordQuery([keyword])} enumerated ${forKeyword.size} of ${required} names across ${cells.length} partition cell(s) plus the keyword's own reachable window, and a second full pass found no more; the refinement keywords do not cover the keyword, so the harvest would be silently short`
         : `npm search for ${keywordQuery([keyword])} enumerated ${forKeyword.size} of ${required} names, and a second full pass found no more; the search ended before reaching the answered total, so the harvest would be silently short`)

--- a/registry/scripts/tests/npm-client.test.ts
+++ b/registry/scripts/tests/npm-client.test.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { FetchTimeoutError, fetchCandidate, fetchCandidates, HARVEST_CONCURRENCY, HARVEST_KEYWORDS, keywordQuery, MAX_SEARCH_FROM, PARTITION_KEYWORDS, partitionKeyword, PEER_NAME_MAX_LENGTH, PEERS_MAX_COUNT, SEARCH_WINDOW, searchByKeywords, toCandidate, withTimeout } from '../src/npm-client.ts'
+import { FetchTimeoutError, fetchCandidate, fetchCandidates, HARVEST_CONCURRENCY, HARVEST_KEYWORDS, keywordQuery, MAX_SEARCH_FROM, MAX_SEARCH_SHORTFALL, type KeywordShortfall, PARTITION_KEYWORDS, partitionKeyword, PEER_NAME_MAX_LENGTH, PEERS_MAX_COUNT, SEARCH_WINDOW, searchByKeywords, toCandidate, withTimeout } from '../src/npm-client.ts'
 import { ENTRY_PAYLOAD_MAX_BYTES, entryPayloadBytes } from '../src/gate.ts'
 import { headersThenBodyError, headersThenSlowBody, headersThenStalledBody } from './stalling-fetch.ts'
 
@@ -1088,8 +1088,14 @@ describe('searchByKeywords', () => {
     // `{"objects":[null]}` is legal JSON too, and `object.package?.name`
     // throws on the element rather than the body. A page entry that names no
     // package is not a package — skipped, exactly like one whose name is not
-    // a string; the coverage check below is what refuses the resulting
-    // shortfall, with the keyword in its message.
+    // a string. That is this test's subject and it is unchanged.
+    //
+    // What its tail asserts DID change: the resulting 1-of-2 shortfall
+    // used to be refused here, and a shortfall of one is now inside
+    // MAX_SEARCH_SHORTFALL, so it is reported and the harvest publishes.
+    // The refusal has not gone anywhere — the 5-of-10 case above and the
+    // one-past-the-bound case in the shortfall describe below both keep
+    // it covered.
     const fetchImpl = (async (url: string | URL) => {
       const params = new URL(String(url)).searchParams
       const query = params.get('text') ?? ''
@@ -1100,10 +1106,73 @@ describe('searchByKeywords', () => {
         objects: [null, { package: { name: 'dsh-real' } }, { package: null }, 'not an object'],
       }), { status: 200 })
     }) as unknown as typeof fetch
-    await expect(searchByKeywords(fetchImpl)).rejects.toThrow(
-      /npm search for keywords:dsh-plugin enumerated 1 of 2 names, and a second full pass found no more; the search ended before reaching the answered total/,
-    )
+    const seen: KeywordShortfall[] = []
+    const names = await searchByKeywords(fetchImpl, undefined, undefined, undefined, undefined, s => seen.push(s))
+    expect(names).toEqual(['dsh-real'])
+    expect(seen).toEqual([{ keyword: 'dsh-plugin', enumerated: 1, required: 2 }])
   })
+
+  describe('a shortfall small enough to be registry noise', () => {
+    // Live on 2026-09-04, `main`'s daily build died here:
+    //   npm search for keywords:dsh-plugin enumerated 3746 of 3747 names,
+    //   and a second full pass found no more
+    // One name out of 3747. The two churn tolerances above cannot help with
+    // it: `Math.min(total, after)` needs the two probes to DISAGREE, and both
+    // answered 3747, while the second full pass re-pages the same cells and
+    // finds the same 3746. This module's own comment names the mechanism —
+    // "Same for a `total` npm overstates by one" — so it is a shortfall no
+    // amount of re-reading can close, and the build simply stopped.
+    //
+    // The scheduled run at 07:58 had passed and the push run at 08:39 failed,
+    // so it is a coin flip per run, and a lost flip freezes the shelf for the
+    // day. A bounded tolerance is the trade: at most MAX_SEARCH_SHORTFALL
+    // names may be missing from one keyword, reported rather than silent,
+    // against a build that publishes.
+
+    /** total 10, page 0 serves `served`, page 1 is empty — the mid-stream
+     * empty page that ends a cell early, which is the reachable shape. */
+    const shortBy = (served: number) => stubSearch(
+      { 'keywords:dsh-plugin': 10, 'keywords:deepseek-harness': 0 },
+      (query, from) => (query === 'keywords:dsh-plugin' && from === 0
+        ? Array.from({ length: served }, (_, i) => `p${i}`)
+        : []),
+    ).fetchImpl
+
+    it('publishes, and reports the shortfall instead of swallowing it', async () => {
+      const seen: { keyword: string; enumerated: number; required: number }[] = []
+      const names = await searchByKeywords(shortBy(9), undefined, undefined, undefined, undefined, (s: KeywordShortfall) => seen.push(s))
+      expect(names).toHaveLength(9)
+      // Not silent: the caller gets the numbers so the build report can carry
+      // them. Nothing else can name the missing package — that is the whole
+      // difficulty — so the count is the honest thing to publish.
+      expect(seen).toEqual([{ keyword: 'dsh-plugin', enumerated: 9, required: 10 }])
+    })
+
+    it('tolerates a shortfall exactly at the bound and refuses one past it', async () => {
+      await expect(searchByKeywords(shortBy(10 - MAX_SEARCH_SHORTFALL))).resolves.toHaveLength(10 - MAX_SEARCH_SHORTFALL)
+      await expect(searchByKeywords(shortBy(10 - MAX_SEARCH_SHORTFALL - 1)))
+        .rejects.toThrow(/enumerated \d+ of 10 names/)
+    })
+
+    it('reports nothing when the keyword enumerated whole', async () => {
+      const seen: unknown[] = []
+      await searchByKeywords(shortBy(10), undefined, undefined, undefined, undefined, (s: KeywordShortfall) => seen.push(s))
+      expect(seen).toEqual([])
+    })
+
+    it('stays well under the smallest coverage gap this repo has actually seen', () => {
+      // The bound is not a round number picked for comfort. Two magnitudes are
+      // recorded in npm-client.ts itself: a genuine partition gap is "hundreds
+      // of names", and PARTITION_KEYWORDS was measured FIFTEEN names short the
+      // day after it was documented as complete. A tolerance at or above 15
+      // would have absorbed that real gap silently.
+      expect(MAX_SEARCH_SHORTFALL).toBeLessThan(15)
+      // And large enough for the mechanisms it exists for: npm overstating a
+      // total by one, plus a page or two serving 249 objects of 250.
+      expect(MAX_SEARCH_SHORTFALL).toBeGreaterThanOrEqual(1)
+    })
+  })
+
 })
 
 describe('fetchCandidate', () => {


### PR DESCRIPTION
## 为什么

`main` 的每日构建正在这里失败。Run [33854473760](https://github.com/LivXue/dsh-plugin-shop/actions/runs/33854473760)，2026-09-04T08:39，push to main，job `build`，step `Classify new listings`：

```
npm search for keywords:dsh-plugin enumerated 3746 of 3747 names,
and a second full pass found no more
```

**3747 里差 1 个。** 已有的两层 churn 容忍都救不了它：`Math.min(total, after)` 需要两次探测**不一致**，而两次都答 3747；第二次完整重跑翻同样的分页、找到同样的 3746。模块自己的注释就点破了机制——*"Same for a `total` npm overstates by one"*。

07:58 的定时构建通过、08:39 这次失败——所以它是**每次构建掷一次硬币**，输一次货架就一天不更新。

## 界怎么定的

`MAX_SEARCH_SHORTFALL = 3`，不是图省事取的整数。这个文件里记着真实缺口的两个量级：分区缺口是 "hundreds of names"，而 `PARTITION_KEYWORDS` 曾在被记为"完备"的**第二天实测少 15 个**。容差取到 15 就会把那次真缺口静默吸收掉。

按真实规模在本分支端到端复现：

| total / served | 结果 |
|---|---|
| 3747 / **3746** ← 线上那次 | 继续，报告 |
| 3747 / 3744（差 3，界上） | 继续，报告 |
| 3747 / 3743（差 4） | **停止** |
| 3747 / 3732（差 15，真实缺口量级） | **停止** |
| 3747 / 3747 | 继续，无报告 |

## 被容忍的亏空不会静默

`searchByKeywords` 把它报给调用方，`report.md` 带上计数——这里没有任何东西能说出缺的是**哪个**包（这正是难点所在），所以计数是唯一诚实的可发布信息。

它也随 harvest handoff 传递，这是最容易做错的一点：**CI 永远带 `--harvest-from`，所以 `build.ts` 自己那次 `searchByKeywords` 在 CI 里根本不执行**。亏空是 `classify.ts` 发现的——线上堆栈正是死在那一行。

## 一个既有测试被改了（不是弄绿）

`skips a null object in a search page` 原本断言它 fixture 产生的 1-of-2 亏空会抛。它真正的主题——null 元素被跳过而非解引用——没变、仍在断言；变的只是后果。抛出本身仍被上面的 5-of-10 用例和新增的越界用例覆盖。

## 范围

针对 `main` 的最小热修：4 个文件，+153/−14。同样的改动也在未合并的审计栈里，另带一个钉住 handoff 契约的 `repo-guards` 守卫——那个文件 main 上还不存在，随栈一起合并。

四个 mutation 已验证：界抬到 15、容差移除、抛出移除、报告丢弃。