### PR TITLE
fix(ci): serialise the catalog harvest across refs, not per ref

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,7 +22,21 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: catalog-${{ github.ref }}
+  # ONE group for every pull-request run, because what this workflow contends
+  # for is a single GitHub token's search quota, not a ref. Grouping by ref let
+  # any number of them run at once: on 2026-09-05 seven catalog runs started
+  # within 90 seconds — a merge to main, a branch push, and the five Dependabot
+  # PRs that landed the moment .github/dependabot.yml did — each running the
+  # full 82-window live harvest on the same token. The search API answered 403
+  # and main's post-merge build died on it, having published nothing.
+  #
+  # With one group and cancel-in-progress, five action-bump PRs collapse to one
+  # run, which is the right answer for them: a SHA bump cannot change the
+  # catalog, and the dry run is there to prove the workflow still parses and
+  # harvests. A legitimate PR's run can be cancelled by a later one; re-run it.
+  #
+  # main keeps its own group so a PR can never cancel a run that publishes.
+  group: catalog-${{ github.event_name == 'pull_request' && 'pull_request' || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/registry/scripts/tests/repo-guards.test.ts
+++ b/registry/scripts/tests/repo-guards.test.ts
@@ -18,6 +18,25 @@ import { parse } from 'yaml'
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
 const read = (relative: string): string => readFileSync(join(repoRoot, relative), 'utf8')
 
+describe('the catalog harvest is serialised across refs', () => {
+  it('puts every pull-request run in ONE concurrency group', () => {
+    // The harvest is bounded by one GitHub token's search quota, not by the
+    // ref, so a per-ref group lets any number of them run at once. Measured
+    // 2026-09-05: seven catalog runs started within 90 seconds — a merge to
+    // main, a branch push, and five Dependabot PRs that landed the moment
+    // .github/dependabot.yml did — each running the full 82-window live
+    // harvest on the same token. The search API answered 403 and main's
+    // post-merge build died on it.
+    //
+    // main keeps its own group, so a PR can never cancel a run that publishes.
+    const workflow = read('.github/workflows/daily.yml')
+    const group = workflow.match(/^\s*group:\s*(.+)$/m)?.[1] ?? ''
+    expect(group, 'daily.yml groups by ref alone, so PR runs do not queue')
+      .toMatch(/pull_request/)
+    expect(group, 'main must not share the pull-request group').toMatch(/github\.ref/)
+  })
+})
+
 describe('what CI publishes to Pages', () => {
   it('uploads the staged directory, never dist itself', () => {
     // `path: dist` published /v1/harvest.json, /v1/report.md and


### PR DESCRIPTION
`main` 08:33Z 的构建失败复盘，那次什么都没发布：

```
Error: github search probe for topic:dsh-plugin stars:0
       created:2019-05-18..2030-10-01 failed: 403
```

## 发生了什么

90 秒内有**七个** `catalog` run 同时开跑：合并到 main、一次分支推送、以及 `.github/dependabot.yml` 落地那一刻 Dependabot 开的**五个 PR**。每个都跑完整的 82 窗口实时 GitHub 采集加最多 2,000 次仓库抓取，全在同一个 token 上——搜索 API 的二级限流回了 403，main 的构建死在 `partitionTopic` 里。

并发组当时是 `catalog-${{ github.ref }}`。**这就是缺陷**：这个 workflow 争的是**一个 token 的搜索配额**，不是 ref，所以按 ref 分组等于让它们全部并行。

## 修法

PR 运行共享一个组；main 保留自己的组，所以 PR 永远不能取消一个正在发布的运行。

配上 `cancel-in-progress`，五个 action bump PR 会塌缩成一次运行——这对它们正合适：SHA bump 改不了目录，空跑的意义只是证明 workflow 还能解析、还能采集。代价是一个正经 PR 的运行可能被后来的取消掉；重跑即可。

## 两件排除掉的可能，都是查过才排除的

- **不是 PAT 推送路径。** 两个 commit 步骤是 `skipped` 而非 `failed`——job 在早四步的 `build:catalog` 就死了。**那条路径至今仍未真正运行过。**
- **不是 plan C task 4 的 `incomplete_results` 重试放大了请求量。** 失败运行的日志里 `incomplete_results` 出现 **0 次**，重试从未触发。

## 线上全程没断

07:40Z 的定时构建已经发布过；这次运行失败期间，线上目录读到的是 `builtAt 2026-09-05T08:16:21Z`、9,631 条。

## 这是 D-10 运维手册在更上一层生效

抛出的细节写着 403，按 plan C task 19 的规矩意味着**被限流而不是坏了**，答案是**减少负载，不要放宽状态判定**。这次的负载是 task 13 自己的 Dependabot 配置造出来的，所以减负载就该落在并发组上。

两个方向都做了 mutation 验证：退回按 ref 分组会红，把 main 也并进 PR 组也会红。758 测试全绿。