### PR TITLE
fix(ci): group the action pairs Dependabot can otherwise split

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,23 @@ updates:
       interval: weekly
     commit-message:
       prefix: 'ci'
-    # One PR per action, so CI judges each bump on its own. A batched PR that
-    # goes red says nothing about which of the bumps did it.
-    open-pull-requests-limit: 5
+    # One PR per action, so CI judges each bump on its own: a batched PR that
+    # goes red says nothing about which of the bumps did it. The exception is a
+    # PAIR of actions that only work at matching versions -- those move as one,
+    # because half a pair is worse than neither half.
+    groups:
+      # upload-artifact writes the artifact that the publish job's
+      # download-artifact reads back. On 2026-09-05 Dependabot proposed
+      # upload-artifact 4.6.2 -> 7.0.1 and left download-artifact at 4.3.0 with
+      # no PR at all, because open-pull-requests-limit cut the list at five.
+      # A dry run cannot catch that mismatch: `publish` is the only job that
+      # downloads, and it is skipped on pull_request.
+      artifact-transfer:
+        patterns: ['actions/upload-artifact', 'actions/download-artifact']
+      # upload-pages-artifact writes what deploy-pages deploys; same argument.
+      pages-deploy:
+        patterns: ['actions/upload-pages-artifact', 'actions/deploy-pages']
+    # High enough that no action is ever silently dropped off the end of the
+    # list. That is what split the artifact pair: the cap was the reason
+    # download-artifact got no PR, not a decision anybody made.
+    open-pull-requests-limit: 10

--- a/registry/scripts/tests/repo-guards.test.ts
+++ b/registry/scripts/tests/repo-guards.test.ts
@@ -114,6 +114,37 @@ describe('workflow action pins', () => {
     }
   })
 
+  it('moves paired actions together, and never drops one off a limit', () => {
+    // upload-artifact writes the artifact the publish job's download-artifact
+    // reads back, and upload-pages-artifact writes what deploy-pages deploys.
+    // Each pair has to move as one. On 2026-09-05 they did not: an
+    // open-pull-requests-limit of 5 made Dependabot propose upload-artifact
+    // 4.6.2 -> 7.0.1 and leave download-artifact at 4.3.0 with no PR at all,
+    // and the mismatch is invisible to a dry run because `publish` — the only
+    // job that downloads — is skipped on pull_request. Merging that PR alone
+    // could have broken publishing on main with nothing red beforehand.
+    //
+    // Parsed, not grepped: a text search for the two names is satisfied by the
+    // COMMENT above each group that happens to mention both, which a mutation
+    // splitting the pages pair proved by leaving the suite green.
+    const config = parse(read('.github/dependabot.yml')) as {
+      updates: { groups?: Record<string, { patterns?: string[] }>; 'open-pull-requests-limit'?: number }[]
+    }
+    const actions = config.updates[0]
+    expect(actions, 'dependabot.yml declares no update block').toBeDefined()
+    const groups = Object.values(actions?.groups ?? {}).map(g => g.patterns ?? [])
+    for (const pair of [['actions/upload-artifact', 'actions/download-artifact'],
+                        ['actions/upload-pages-artifact', 'actions/deploy-pages']]) {
+      expect(
+        groups.some(p => pair.every(name => p.includes(name))),
+        `${pair.join(' and ')} are not in one group, so Dependabot can move one without the other`,
+      ).toBe(true)
+    }
+    // And the cap must not be what decides which actions get proposed: it was
+    // the reason download-artifact got no PR, not a decision anybody made.
+    expect(actions?.['open-pull-requests-limit'] ?? 0).toBeGreaterThanOrEqual(10)
+  })
+
   it('asks Dependabot to keep the pins current', () => {
     // A SHA pin that nobody bumps is a security patch nobody applies. The
     // weekly PR is the other half of the trade.


### PR DESCRIPTION
## 问题

`actions/upload-artifact` 写的那个 artifact，正是 `publish` job 里 `actions/download-artifact` 读回来的。2026-09-05 Dependabot 提议了 `upload-artifact 4.6.2 → 7.0.1`（PR #9），却**完全没有为 `download-artifact` 开 PR**，它留在 4.3.0。合掉那一个 PR 就等于只搬走了一对里的一半。

**这个不匹配在构造上就躲开了 CI**：`publish` 是唯一会 download 的 job，而它在 `pull_request` 事件里是 skipped。空跑碰不到这个配对，问题只会在合并之后、在发布那个 job 里现形。

## 原因

是这个文件自己的 `open-pull-requests-limit: 5`。有 6 个 action 有更新，上限把列表截在 5 个，`download-artifact` 掉出了末尾。

**哪些 action 会被提议，是被一个数字决定的，不是被任何人决定的。**

## 改法

两对（artifact 传输、pages 部署）变成 group；上限提到 10，高到它不再决定列表内容。

其余仍然一个 action 一个 PR——task 13 给的理由依然成立：批量 PR 红了，说明不了是哪个 bump 干的。例外只留给"版本必须匹配才工作"的配对，因为**半对比一对都没有更糟**。

## 守卫解析 YAML，不扫文本

第一版扫文本找一对里的两个名字，结果被每个 group 上方**同时提到这两个名字的注释**满足了——拆散 pages 对的 mutation 让整套保持绿。改成解析后，三个 mutation 全部被抓：两对各拆一次、上限退回 5。

## 同一轮调查里的另外两条（本 PR 不改，记录在提交信息里）

- `actions/checkout` 到 v7 仍有 `persist-credentials`、默认 `true`，所以 Task 15 的修复能活过那次升级。但 **v6 起凭据挪出了 `.git/config`，改存到 `$RUNNER_TEMP` 下的文件**。危害不变、修法不变，但 `daily.yml` 里那段注释专门点名了 `.git/config`，checkout 一升就要改措辞。
- 现在开着的五个 bump PR 全是跨大版本，而它们眼下的红绿**不构成任何一方的证据**：2026-09-05 有七个 catalog run 抢同一个 token 的搜索配额，三个死在 403 上。等 PR 运行共享并发组之后，需要一个一个重跑。