### PR TITLE
Audit fixes E — close the test gaps (H-1 … H-11)

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -57,5 +57,13 @@ jobs:
       # chromium's system libraries, add it only if the runner proves otherwise.
       - run: pnpm -C packages/dsh-plugin-shop exec playwright install chromium
       - run: pnpm -C packages/dsh-plugin-shop test
+        env:
+          # These two files ARE the P1 and P2 exit criteria, and both skip when
+          # they cannot find a working `dsh`. That is right on a developer's
+          # machine and wrong here, where the two steps above exist precisely to
+          # install the harness and the browser. Reproduced 2026-09-05: with
+          # `dsh` hidden from PATH the suite reported `1 skipped` and exited 0,
+          # so a green run was not evidence either criterion had executed.
+          DSH_SHOP_REQUIRE_E2E: '1'
       - run: pnpm -C packages/dsh-plugin-shop typecheck
       - run: pnpm -C packages/dsh-plugin-shop build

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -53,7 +53,7 @@ Tasks 1, 3, 4, 5, 6, 7, 8, 9 are independent of A–D and can land in any order,
 
 The gap: the current test reads `index.plugins.sha256` and asserts `pluginsFileName === plugins.${that}.json`. Both sides come from the same variable, so hashing bytes other than the ones written leaves it green — and the host's integrity check (`packages/dsh-plugin-shop/src/host/catalog.ts:400-402`) then refuses every published catalog while CI passes.
 
-- [ ] **Step 1: Prove the gap — inject the mutation**
+- [x] **Step 1: Prove the gap — inject the mutation**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -66,7 +66,7 @@ npx vitest run registry/scripts/tests/emit.test.ts
 
 Expected: `Tests  31 passed (31)`. The suite is green while every published `index.json` points at a sha256 no consumer can reproduce.
 
-- [ ] **Step 2: Write the test that catches it**
+- [x] **Step 2: Write the test that catches it**
 
 Add `import { createHash } from 'node:crypto'` as the first import of `registry/scripts/tests/emit.test.ts`, then replace lines 74-80 with:
 
@@ -108,13 +108,13 @@ Add `import { createHash } from 'node:crypto'` as the first import of `registry/
   })
 ```
 
-- [ ] **Step 3: Run it against the mutated copy to verify it fails**
+- [x] **Step 3: Run it against the mutated copy to verify it fails**
 
 Run: `npx vitest run registry/scripts/tests/emit.test.ts`
 
 Expected: FAIL, 2 failed | 30 passed (32). Both new cases report `AssertionError: expected 'fcc218afb1ba02b628335c4960a70f954ddc6f0f90514ceb5c85b4288188cbb5' to be 'a71134b3602c819801bee41194843d2cae976f98d8995fb8242df20cd01538fc' // Object.is equality` (the mutated hash against the recomputed one; the digests differ for any fixture, these are the values for the two-entry case).
 
-- [ ] **Step 4: Restore the module and run it green**
+- [x] **Step 4: Restore the module and run it green**
 
 ```bash
 cp /tmp/emit.ts.orig registry/scripts/src/emit.ts
@@ -126,7 +126,7 @@ pnpm typecheck
 
 Expected: PASS — `emit.test.ts (32 tests)`, root total **335 passed (335)**, typecheck clean.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/emit.test.ts
@@ -452,7 +452,7 @@ code, both stayed green. Two fixtures, one per mutation: two ERR_ codes
 
 **No mutation step.** This is an absence, not a surviving mutation: there is no line to mutate, because the failure mode is that the P1 and P2 exit criteria *do not run at all* and the run is green anyway. The reproduction is the skip itself, which Step 1 exercises directly.
 
-- [ ] **Step 1: Reproduce the gap — hide `dsh` and watch both criteria vanish silently**
+- [x] **Step 1: Reproduce the gap — hide `dsh` and watch both criteria vanish silently**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -464,7 +464,7 @@ echo "exit: $?"
 
 Expected: `Tests  no tests` / `5 skipped`, **exit 0**. The P1 and P2 exit criteria did not execute and nothing said so. Note also that `plugin.yml:24` gates on `dsh --version` — a bare-name spawn — while `real-install.test.ts:28-47` probes through `dshCommand`/`resolveDshScript`; the two can disagree, so a green CI run today is not evidence either criterion ran.
 
-- [ ] **Step 2: Write the test that catches it**
+- [x] **Step 2: Write the test that catches it**
 
 In `packages/dsh-plugin-shop/tests/host/real-install.test.ts`, after the `hasDsh` IIFE (line 47) add:
 
@@ -536,7 +536,7 @@ with:
           DSH_SHOP_REQUIRE_E2E: '1'
 ```
 
-- [ ] **Step 3: Run it and verify it fails when the criteria would skip**
+- [x] **Step 3: Run it and verify it fails when the criteria would skip**
 
 ```bash
 env PATH=/usr/bin:/bin DSH_SHOP_REQUIRE_E2E=1 npx vitest run --root packages/dsh-plugin-shop \
@@ -553,7 +553,7 @@ env PATH=/usr/bin:/bin npx vitest run --root packages/dsh-plugin-shop \
 
 Expected: PASS, 2 passed | 5 skipped — no dsh, no chromium, no false alarm.
 
-- [ ] **Step 4: Run the full suites green with the CLI present**
+- [x] **Step 4: Run the full suites green with the CLI present**
 
 ```bash
 pnpm -C packages/dsh-plugin-shop test
@@ -563,7 +563,7 @@ pnpm -C packages/dsh-plugin-shop typecheck
 
 Expected: PASS both ways — `tests/host/real-install.test.ts (2 tests)`, `tests/client/web-full-flow.e2e.ts (5 tests)`, package total **496 passed (496)**.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/dsh-plugin-shop/tests/host/real-install.test.ts \
@@ -601,7 +601,7 @@ turns each skip into a failed assertion; plugin.yml sets it."
 
 **No mutation step.** The finding is that the branch *cannot* be mutated into failing: any input that would make it fire is unreachable through `emit`'s signature. Step 1 demonstrates that instead.
 
-- [ ] **Step 1: Demonstrate the branch is unreachable — mutate its condition and watch nothing change**
+- [x] **Step 1: Demonstrate the branch is unreachable — mutate its condition and watch nothing change**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -618,7 +618,7 @@ cp /tmp/emit.ts.h5.orig registry/scripts/src/emit.ts
 git diff --numstat registry/scripts/src/emit.ts   # must print nothing
 ```
 
-- [ ] **Step 2: Write the test that pins the property**
+- [x] **Step 2: Write the test that pins the property**
 
 Add to `describe('emit')` in `registry/scripts/tests/emit.test.ts`, after the `stamps the schema version on both files` case:
 
@@ -643,7 +643,7 @@ Add to `describe('emit')` in `registry/scripts/tests/emit.test.ts`, after the `s
   })
 ```
 
-- [ ] **Step 3: Delete the dead branch**
+- [x] **Step 3: Delete the dead branch**
 
 Remove these four lines from `registry/scripts/src/emit.ts` (lines 220-223, immediately before `return { pluginsFileName, ... }`):
 
@@ -664,7 +664,7 @@ and replace them with:
   // EMITTED artifacts instead, which is a check that can actually fail.
 ```
 
-- [ ] **Step 4: Run it green**
+- [x] **Step 4: Run it green**
 
 ```bash
 npx vitest run registry/scripts/tests/emit.test.ts
@@ -674,7 +674,7 @@ pnpm typecheck
 
 Expected: PASS — `emit.test.ts (33 tests)`, root total **339 passed (339)**, typecheck clean (the removal drops the only use of `dataCount`, so an unused-variable error here means the replacement was pasted in the wrong place).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/src/emit.ts registry/scripts/tests/emit.test.ts
@@ -718,7 +718,7 @@ The audit marks H-7 *Plausible*, so Step 1 is the reproduction that confirms or 
 
 **No mutation step.** There is no production line to mutate: the defect is in the tests' own path resolution, and Step 1 reproduces it directly by changing the cwd.
 
-- [ ] **Step 1: Reproduce — run the suite from a subdirectory**
+- [x] **Step 1: Reproduce — run the suite from a subdirectory**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store/registry
@@ -742,7 +742,7 @@ grep -rn "readFileSync('registry\|readFileSync(\"registry" registry/scripts/test
 grep -rn "readFileSync('packages\|readFileSync(\"packages" packages/dsh-plugin-shop/tests/
 ```
 
-- [ ] **Step 2: Fix both paths and write the guard**
+- [x] **Step 2: Fix both paths and write the guard**
 
 `registry/scripts/tests/pipeline.test.ts` lines 1-9 become:
 
@@ -835,7 +835,7 @@ describe('fixture and artifact paths', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the guard fails on the defect it names**
+- [x] **Step 3: Verify the guard fails on the defect it names**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -852,7 +852,7 @@ npx vitest run registry/scripts/tests/cwd-independence.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 4: Run it green, from both directories**
+- [x] **Step 4: Run it green, from both directories**
 
 ```bash
 npx vitest run registry/scripts/tests/pipeline.test.ts registry/scripts/tests/schema.test.ts
@@ -863,7 +863,7 @@ pnpm typecheck
 
 Expected: PASS everywhere — 20 + 6 tests from the subdirectory too, root total **340 passed (340)** across **23 files**.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/pipeline.test.ts registry/scripts/tests/schema.test.ts \
@@ -1440,7 +1440,7 @@ bare not.toThrow()/toBeTruthy() assertions in dsh-cli and hot."
 
 **No mutation step at HEAD**, because the code to mutate does not exist yet; Step 2 mutation-checks plan C's function once it does.
 
-- [ ] **Step 1: Resolve the real names plan C landed**
+- [x] **Step 1: Resolve the real names plan C landed**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -1451,7 +1451,7 @@ grep -n "stars" registry/scripts/src/build.ts
 
 Expected: `serializeStars` and `SerializedStars` exported from `registry/scripts/src/stars-assemble.ts`, and no `createHash` left in `build.ts`'s stars path. If `serializeStars` is absent, **stop**: plan C's C-3 has not landed and `build.ts` still hashes the sidecar inline, so there is nothing pure to test.
 
-- [ ] **Step 2: Prove the gap — inject the mutation into plan C's serialiser**
+- [x] **Step 2: Prove the gap — inject the mutation into plan C's serialiser**
 
 ```bash
 cp registry/scripts/src/stars-assemble.ts /tmp/stars-assemble.ts.orig
@@ -1463,7 +1463,7 @@ npx vitest run registry/scripts/tests/stars-assemble.test.ts
 
 Expected: GREEN. Plan C's own order-independence test compares two `json` values with each other and never checks the digest against those bytes, so the file name can point at a hash of something else — and the host verifies sha256 on the fetched sidecar bytes (`host/catalog.ts:400-402`), so every reader would refuse it.
 
-- [ ] **Step 3: Write the test that catches it**
+- [x] **Step 3: Write the test that catches it**
 
 Add to plan C's stars-serialiser test file (adding `import { createHash } from 'node:crypto'` if it is not already there):
 
@@ -1488,7 +1488,7 @@ Add to plan C's stars-serialiser test file (adding `import { createHash } from '
   })
 ```
 
-- [ ] **Step 4: Restore the module and run it green**
+- [x] **Step 4: Restore the module and run it green**
 
 ```bash
 npx vitest run registry/scripts/tests/stars-assemble.test.ts
@@ -1502,7 +1502,7 @@ pnpm typecheck
 
 Expected: PASS. The root total is plan C's total **plus exactly one** — record the before and after numbers from the two `pnpm test` runs rather than trusting an absolute figure this plan cannot know.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/stars-assemble.test.ts

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -37,6 +37,12 @@ Tasks 1, 3, 4, 5, 6, 7, 8, 9 are independent of A–D and can land in any order,
 
 ### Task 1: H-1 — name the plugins file by the bytes it actually writes
 
+> **Outcome: DONE.** The gap was reproduced first, as the task asks: replacing
+> `update(pluginsJson)` with `update(JSON.stringify(sorted))` — the same data,
+> a different serialisation — left **38 of 38 green**. The test now recomputes
+> the hash from the emitted bytes rather than reading it back out of the index,
+> and that mutation goes red.
+
 **Files:**
 - Modify: `registry/scripts/tests/emit.test.ts:74-80` (the tautological test) and add one case after it
 - Read only: `registry/scripts/src/emit.ts:176` (`const sha256 = createHash('sha256').update(pluginsJson).digest('hex')`)
@@ -555,6 +561,14 @@ turns each skip into a failed assertion; plugin.yml sets it."
 
 ### Task 5: H-5 — remove the throw that cannot fire, and assert the property it claimed
 
+> **Outcome: DONE — branch deleted, property kept.** The throw at `emit.ts` was
+> unreachable exactly as the task argues: `pluginsJson` is built from `sorted`
+> a few lines above, and `JSON.stringify` cannot change an array's length, so
+> both counts came from the same array by construction. The comparison now
+> lives in `emit.test.ts` between the two EMITTED artifacts, where it can go red
+> if they are ever built from different sources. `assertCatalogInvariants` is
+> untouched.
+
 **Files:**
 - Modify: `registry/scripts/src/emit.ts:220-223` (delete the dead branch)
 - Modify: `registry/scripts/tests/emit.test.ts` — add one case to `describe('emit')`, after the schema-version case that ends at line 96
@@ -656,6 +670,20 @@ artifacts, where it can fail if they ever stop sharing a source."
 ---
 
 ### Task 6: H-7 — resolve fixture paths from the module, not the cwd
+
+> **Outcome: DONE, and the finding was wider than Plausible.** Step 1
+> reproduced it: running `pipeline.test.ts` from `/tmp` with an explicit
+> `--root` raised `ENOENT` and reported **"no tests"** rather than a failure —
+> the shape that hides.
+>
+> `cwd-independence.test.ts` then found a **second** instance the audit did not
+> name: `schema.test.ts` read `registry/schema/plugin-entry.schema.json` the
+> same way. Both now resolve from the module.
+>
+> Verified end to end: the whole suite run from `/tmp` is 28 files, 760 tests,
+> all passing. The guard scans source rather than re-running each file from a
+> foreign directory, which would double the suite's runtime to catch a defect
+> whose signature is one regex.
 
 **Files:**
 - Modify: `registry/scripts/tests/pipeline.test.ts:1-9`
@@ -1360,6 +1388,13 @@ bare not.toThrow()/toBeTruthy() assertions in dsh-cli and hot."
 ---
 
 ### Task 10: H-1b — recompute the stars sidecar's hash (after plan C)
+
+> **Outcome: ALREADY SATISFIED by plan C's task 9, which landed the serialiser
+> this task was waiting for.** Verified 2026-09-05 by the mutation this task
+> specifies: replacing `update(json)` with `update(JSON.stringify(sorted))` in
+> `serializeStars` turns `stars-assemble.test.ts` red. The recomputation idiom
+> was written into that test when the function was created, so there is nothing
+> further to add.
 
 **Files:**
 - Modify: `registry/scripts/tests/stars-assemble.test.ts` — the module plan C extends with its pure serialiser

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -1800,6 +1800,8 @@ Closed by `2184265`: an `expandGlobalPlane` helper opens the 全局插件 disclo
 
 **Verification:** none — closed and green in CI.
 
+> **Reviewed 2026-09-05 — no work, as recorded.** Left as the standing hazard it describes: `plugin.yml`'s pin to `0.1.2-rc.1` and its measured contract table are still the only thing holding the e2e's selectors to a harness contract this repository does not own.
+
 ---
 
 ### Task 13: H-11 — the temp-home leak is in the host tests, not in the e2e file the finding names
@@ -1817,11 +1819,23 @@ tests/client/web-full-flow.e2e.ts    mkdtempSync=2    rmSync=2    ← balanced
 
 `web-full-flow.e2e.ts` already cleans up: `afterAll` at `:237`, `rmSync(tmpHome, { recursive: true, force: true })` at `:248`. The leak is in the host tests, and `index.test.ts` alone accounts for 39 of the unbalanced sites. The surviving directory names agree — `dsh-restart-guard` 476, `dsh-restart-guard-cache` 476, `dsh-shop` 442, `dsh-gateway-profile` 442, `dsh-gateway-fixture` 442, `dsh-profile` 320, `dsh-fixture` 280, `dsh-hot-profile` 272 — all host-test scenario names. 5,089 directories present when this task was written; the audit measured 9,769 two days earlier and clearing them did not fix H-10.
 
+> **Executed 2026-09-05. Worse than measured, and fixed with one root per file rather than paired removals.**
+>
+> Re-measured on `5988921`: **101** `mkdtempSync` sites under `tests/host/` against 12 removals, leaving **203** directories per run — not the 39 this task estimated. `index.test.ts` alone had grown from 41 sites to 59, `executor.test.ts` from 10 to 15. /tmp held **8,878**, cleared by hand after the fix.
+>
+> Two departures from the steps as written:
+> 1. **The guard runs the host directory under an isolated `TMPDIR`, not a count of `/tmp`.** `os.tmpdir()` reads `TMPDIR` first on POSIX, so every scenario's directory lands in a sandbox this test owns. A `/tmp` count races with any other suite on the machine and inherits whatever backlog is already there — it would have been green on a busy machine and red on an idle one for reasons unrelated to the code. The guard lives at `tests/`, not `tests/host/`, because a guard inside the directory it runs would spawn itself.
+> 2. **Vitest's own `VITEST*` variables are stripped from the child environment.** Inherited, the nested run believes it is a worker of the outer one and exits non-zero before running anything — which failed the guard for a reason that had nothing to do with temporary directories, and would have turned it green the moment the leak was fixed for the same wrong reason. This cost one debugging round and is the kind of thing that makes a guard look like it works.
+>
+> The fix is `tests/host/temp-root.ts`: `fileTempRoot(label)` creates one root per file and registers a single `afterAll` removal. Paired `rmSync` calls could not have held — a scenario that throws never reaches its own cleanup, and a scenario copied from another inherits the creation without the removal. Nine host files re-rooted, 101 sites, no scenario's assertions touched.
+>
+> Mutation-checked twice: dropping the `afterAll` leaves 9 roots behind, and reverting `index.test.ts` alone to `tmpdir()` leaves 139. Package suite **633 passed (633)** across 29 files, typecheck clean.
+
 **Files:**
 - Modify: `packages/dsh-plugin-shop/tests/host/index.test.ts`, `executor.test.ts`, `dsh-cli.test.ts`, `profile.test.ts`, `restart.test.ts`
 - Test: `packages/dsh-plugin-shop/tests/host/temp-home-leak.test.ts` (new)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `tests/host/temp-home-leak.test.ts`. It counts `/tmp/dsh-*` directories, runs the host suite in a child process, and counts again:
 
@@ -1849,17 +1863,17 @@ describe('the host suite leaves no temporary DSH_HOME behind', () => {
 }, 300_000)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `npx vitest run tests/host/temp-home-leak.test.ts` from `packages/dsh-plugin-shop`. Expected: FAIL, `expected 5128 to be 5089` or similar — `index.test.ts` alone leaks 39 per run.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 Prefer **one per-run parent** over 41 individual `rmSync` calls: give each file a `mkdtempSync(join(tmpdir(), 'dsh-<file>-'))` root created in `beforeAll`, build every scenario home beneath it, and remove the root in `afterAll` with `rmSync(root, { recursive: true, force: true })`. One cleanup site per file cannot drift out of sync with the creation sites the way 41 paired calls can, and a test that throws mid-scenario still gets its directory removed.
 
 Do not change what any scenario asserts. The homes are inputs, not subjects.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run tests/host/temp-home-leak.test.ts` — Expected: PASS.
 Run: `pnpm -C packages/dsh-plugin-shop test` — Expected: PASS, 26 files / 520 tests (25/519 at `5f48787` plus this file's one case).
@@ -1867,7 +1881,7 @@ Run: `pnpm -C packages/dsh-plugin-shop typecheck` — Expected: no output.
 
 Clear the backlog once, by hand, after the fix is in: `find /tmp -maxdepth 1 -type d -name 'dsh-*' -exec rm -rf {} +`. It matches no `claude-*` path and, being `-type d`, skips a packed `.tgz` sitting beside them.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/dsh-plugin-shop/tests/host/

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -1531,7 +1531,19 @@ with each other and never checks the digest against them."
 
 **No mutation step.** The gap is a perturbation never applied and artifacts never compared — an absence. Step 1 reproduces the specific hole plan B closes, so the test is known to bite.
 
-- [ ] **Step 1: Reproduce the hole — reverse two same-named repo candidates**
+> **Executed 2026-09-05. Most of this had already landed with plans B and C; what remained was the deletion and one perturbation.**
+>
+> `describe('determinism under every perturbation')` (`pipeline.test.ts:575`) was written by plan B's C-2 work and is stronger than this task's Step 2 block: it perturbs npm candidates, repo candidates **and** pre-existing rejections together, over all six artifacts plus `firstSeen`, and its fixtures carry ties this task's did not — two subpackages of one monorepo, a bundle name claimed by two owners, and two *rejected* subpackages of a third. Rewriting it from Step 2 would have lost coverage, so it was extended rather than replaced.
+>
+> What was actually missing:
+> 1. **The repeated run.** Both existing cases compare a base against a *reversed* input; neither runs the same input twice, which is the only leg that separates nondeterminism inside `emit` from an ordering bug. Added, with the sidecar-pointer assertion carried over from the deleted stars case.
+> 2. **The three superseded partial cases** at `:104`, `:171` and `:181` were still present. Deleted — that was this task's point.
+>
+> Both of Step 3's mutations were run before and after the deletion. Reverting `compareEntries` to the name-only comparator fails the reversed leg (`pluginsFileName moved with input order`); `builtAt` inside the hashed content fails the clock case. A third, `nonce: Math.random()` in the hashed content, fails the repeat leg (`moved between runs`) and would have passed every case that existed before this change. Root suite **760 passed (760)**, exactly −3 for the three deletions; typecheck clean.
+>
+> The Step 2 stars case could not be written as specified: plan C's serialiser takes ENTRIES (`assembleStarsForEntries(entries, searchStars, graphqlStars)`), not `(candidates, repoCandidates)`, and its order-independence is already pinned by `stars-assemble.test.ts:124` beside the byte-exact hash at `:111` — which is the right place for it, since the perturbation is the assembler's own.
+
+- [x] **Step 1: Reproduce the hole — reverse two same-named repo candidates**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -1552,7 +1564,7 @@ pluginsJson equal: false   pluginsFileName equal: false   manifestLock equal: fa
 
 172 bundle names over 451 live entries are claimed by several repositories, so this is not a hypothetical shape.
 
-- [ ] **Step 2: Write the one test**
+- [x] **Step 2: Write the one test**
 
 Delete lines 144-151, then 134-142, then 81-88 (highest first, so the earlier line numbers stay valid), and add this block at the end of `registry/scripts/tests/pipeline.test.ts`:
 
@@ -1684,7 +1696,7 @@ describe('determinism', () => {
 
 Extend the imports at the top of the file: add `RepoCandidate` to the `types.ts` type import (`import type { Candidate, Rejection, RepoCandidate } from '../src/types.ts'`), and add `import { assembleStarsByKey } from '../src/stars-assemble.ts'` plus `import { serializeStars } from '../src/stars-assemble.ts'` (plan C puts the serialiser beside the assembler).
 
-- [ ] **Step 3: Verify each perturbation bites**
+- [x] **Step 3: Verify each perturbation bites**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -1719,7 +1731,7 @@ npx vitest run registry/scripts/tests/pipeline.test.ts
 
 Expected: FAIL — `carries the clock in the index and the badge, and nowhere else` reports `pluginsJson moved with the clock: expected -1 to be 0`. Restore again and confirm `git diff --numstat` prints nothing.
 
-- [ ] **Step 4: Run it green**
+- [x] **Step 4: Run it green**
 
 ```bash
 npx vitest run registry/scripts/tests/pipeline.test.ts
@@ -1730,7 +1742,7 @@ pnpm typecheck
 
 Expected: PASS. The root total is plan C's + Task 10's total **minus exactly two** (three partial determinism cases replaced by three that together cover all six artifacts, both orders, the clock and the sidecar). Record the before and after numbers from the two `pnpm test` runs; a delta other than −2 means one of the three old cases was not deleted or an extra was added.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/pipeline.test.ts

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -421,6 +421,22 @@ code, both stayed green. Two fixtures, one per mutation: two ERR_ codes
 
 ### Task 4: H-4 — a CI run may not be green because the exit criteria skipped
 
+> **Outcome: DONE.** Step 1 reproduced it: with `dsh` hidden from PATH,
+> `real-install.test.ts` reported `1 skipped` and the run **exited 0**. The P1
+> exit criterion did not execute and nothing said so.
+>
+> `DSH_SHOP_REQUIRE_E2E=1` now turns that skip into a failure, and `plugin.yml`
+> sets it on the package-suite step — that workflow installs the harness and a
+> browser two steps earlier for exactly this purpose, so a skip there is a green
+> run that proves nothing. A developer's machine without `dsh` still skips
+> quietly, which is the honest case.
+>
+> The guard over the workflow parses the YAML. Its first version sliced 500
+> characters after the `run:` line, and the comment explaining the variable
+> pushed the variable itself out of the window — a correct workflow read as
+> broken. Same lesson as the Dependabot pairing guard the same day: grep the
+> shape and you match the prose.
+
 **Files:**
 - Modify: `packages/dsh-plugin-shop/tests/host/real-install.test.ts:18-47` (add the flag) and add one guard case
 - Modify: `packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts:85-100` (add the flag) and add one guard describe

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -160,7 +160,9 @@ grep -n "catch" registry/scripts/src/npm-client.ts | sed -n '1,20p'
 
 No test calls `fetchCandidates` today — `npm-client.test.ts:245` only mentions it in a comment. Both the mislabelled code and the dropped rejection survive, and a dropped rejection is exactly the silent disappearance CLAUDE.md forbids. `pipeline.test.ts:73-79` feeds a hand-built `fetch-failed` row, so it tests emit's merging, never the mapping.
 
-- [ ] **Step 1: Prove the gap — inject the mutation**
+> **Executed 2026-09-05 — already satisfied, nothing written.** A `describe('fetchCandidates')` block now sits at `npm-client.test.ts:1570`, carrying plan A's D-2 work and naming H-2 in its own comment. Both of Step 1's mutations were run against it and **both are caught**: mislabelling the code as `no-bundle` turns 3 cases red, dropping the rejection turns 4 red. Coverage exceeds what this task specified — six cases, including the 500 path, the transport throw, a stalled connection, the backup registry, a null packument body, and a sliding-pool case (`keeps every slot working while one name stalls`) that this task could not have written: `HARVEST_CONCURRENCY` is no longer a batch barrier, so Step 2's third fixture describes a mechanism that no longer exists.
+
+- [x] **Step 1: Prove the gap — inject the mutation**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -177,7 +179,7 @@ npx vitest run registry/scripts/tests/npm-client.test.ts
 
 Expected: `Tests  53 passed (53)` for **both** mutations.
 
-- [ ] **Step 2: Write the test that catches it**
+- [x] **Step 2: Write the test that catches it**
 
 Change line 2 to `import { fetchCandidate, fetchCandidates, HARVEST_KEYWORDS, PEERS_MAX_COUNT, searchByKeywords, toCandidate } from '../src/npm-client.ts'`, then append after the `describe('fetchCandidate')` block:
 
@@ -260,13 +262,13 @@ describe('fetchCandidates', () => {
 })
 ```
 
-- [ ] **Step 3: Run it against the mutated copy to verify it fails**
+- [x] **Step 3: Run it against the mutated copy to verify it fails**
 
 Run: `npx vitest run registry/scripts/tests/npm-client.test.ts` (with mutation (b) still applied from Step 1)
 
 Expected: FAIL. `records an unfetchable name as fetch-failed…` reports `AssertionError: expected [] to deeply equal [ { name: 'dsh-bad', code: 'fetch-failed', … } ]`; `reports every unfetchable name…` reports `expected [] to deeply equal [ 'dsh-a', 'dsh-b', 'dsh-c' ]`. Re-apply mutation (a) and re-run: the same two fail with `expected 'no-bundle' to be 'fetch-failed'` / the `code` field of the deep-equal diff.
 
-- [ ] **Step 4: Restore the module and run it green**
+- [x] **Step 4: Restore the module and run it green**
 
 ```bash
 cp /tmp/npm-client.ts.orig registry/scripts/src/npm-client.ts
@@ -278,7 +280,7 @@ pnpm typecheck
 
 Expected: PASS — `npm-client.test.ts (56 tests)`, root total **338 passed (338)** (335 after Task 1 plus three).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/npm-client.test.ts
@@ -304,7 +306,9 @@ throw path (D-2), and every failure in one batch."
 
 The documented rule is "Scanning from the end: a pnpm error code first, then any thrown error, then the last line that is not noise." Both existing verbatim fixtures carry exactly one diagnostic line, so neither half of the ordering is pinned.
 
-- [ ] **Step 1: Prove the gap — inject the mutation**
+> **Executed 2026-09-05, as written.** Both mutations survived the pre-existing suite (43 passed under each), and each now turns exactly one of the two new cases red — neither fixture catches the other's mutation, which is why the task asked for both. Line numbers had moved: `installFailureDetail` is at `executor.ts:118` (the picker at `:128-131`), and the describe block runs `executor.test.ts:404-483`. Package suite **632 passed (632)** across 28 files, typecheck clean.
+
+- [x] **Step 1: Prove the gap — inject the mutation**
 
 **Mutation (a) — first match instead of last.** Drop the reverse:
 
@@ -335,7 +339,7 @@ npx vitest run --root packages/dsh-plugin-shop tests/host/executor.test.ts
 
 Expected: `Tests  30 passed (30)` — green again. Both halves of the documented ordering can be inverted with the suite none the wiser.
 
-- [ ] **Step 2: Write the test that catches it**
+- [x] **Step 2: Write the test that catches it**
 
 Insert before the closing `})` of `describe('installFailureDetail')` (currently line 473):
 
@@ -388,13 +392,13 @@ Insert before the closing `})` of `describe('installFailureDetail')` (currently 
   })
 ```
 
-- [ ] **Step 3: Run it against the mutated copy to verify it fails**
+- [x] **Step 3: Run it against the mutated copy to verify it fails**
 
 Run: `npx vitest run --root packages/dsh-plugin-shop tests/host/executor.test.ts`
 
 Expected: FAIL, one case per mutation. With mutation (a) applied: `picks the LAST pnpm error code…` fails on `expected 'pnpm failed in the profile. Run: dsh plugin --profile web install — [ERR_PNPM_PEER_DEP_ISSUES] Unmet peer dependencies' not to match /ERR_PNPM_PEER_DEP_ISSUES/`. With mutation (b) applied: `prefers a pnpm error code over a thrown error…` fails on `expected 'pnpm failed in the profile. Run: dsh plugin --profile web install — TypeError: Cannot read properties of undefined (reading 'bundles')' to match /ERR_PNPM_NO_MATCHING_VERSION/`. Apply each mutation in turn and confirm one case turns red each time — neither mutation is caught by the other's fixture, which is why both are needed.
 
-- [ ] **Step 4: Restore the module and run it green**
+- [x] **Step 4: Restore the module and run it green**
 
 ```bash
 cp /tmp/executor.ts.orig packages/dsh-plugin-shop/src/host/executor.ts
@@ -405,7 +409,7 @@ pnpm -C packages/dsh-plugin-shop typecheck
 
 Expected: PASS — `tests/host/executor.test.ts (32 tests)`, package total **494 passed (494)**.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/dsh-plugin-shop/tests/host/executor.test.ts

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -892,7 +892,9 @@ from the module, and a new guard test fails on the next cwd-relative path."
 
 **No mutation step.** The gap is a missing fixture, not a surviving mutation — there is no code path to break, because the path is never walked. Step 1 confirms the row does not exist today.
 
-- [ ] **Step 1: Confirm the row is never produced**
+> **Executed 2026-09-05, as written.** The predicted row is byte-for-byte what the pipeline produces: `| dsh-bad-catalog | invalid-catalog | dsh.catalog.(root): Unrecognized key: "tags \\| extra" |`. Both new assertions were run with the fixture stashed and both fail there, so the fixture is what carries them. `Accepted: 3` and the listed set are unchanged; `Rejected:` moves from 4 to 5. Root suite **763 passed (763)** across 28 files, typecheck clean.
+
+- [x] **Step 1: Confirm the row is never produced**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -902,7 +904,7 @@ grep -rn "invalid-catalog" registry/scripts/tests/pipeline.test.ts || echo "pipe
 
 Expected: no fixture entry and no pipeline assertion. `emit.test.ts:151-155` escapes a *hand-built* rejection, so the escaping is covered but the mapping from a real candidate is not.
 
-- [ ] **Step 2: Add the fixture candidate**
+- [x] **Step 2: Add the fixture candidate**
 
 In `registry/scripts/tests/fixtures/packuments.json`, add a comma after the `dsh-no-summary` object's closing brace (line 99) and insert before the closing `]`:
 
@@ -925,7 +927,7 @@ In `registry/scripts/tests/fixtures/packuments.json`, add a comma after the `dsh
 
 The unrecognised key is the one rejection whose `detail` echoes author text back into a published artifact, and the `|` inside it is why `escapeCell` exists. Everything else about the candidate is valid — a real license, a real bundle, a perfectly usable npm description — so the only reason it can fail to list is the declared section.
 
-- [ ] **Step 3: Write the assertions and verify they fail without the fixture**
+- [x] **Step 3: Write the assertions and verify they fail without the fixture**
 
 Replace `registry/scripts/tests/pipeline.test.ts:65-71` with:
 
@@ -968,7 +970,7 @@ Expected: FAIL, 2 failed — `reports all five rejections…` on the `dsh-bad-ca
 git stash pop
 ```
 
-- [ ] **Step 4: Run it green**
+- [x] **Step 4: Run it green**
 
 ```bash
 npx vitest run registry/scripts/tests/pipeline.test.ts
@@ -978,7 +980,7 @@ pnpm typecheck
 
 Expected: PASS — `pipeline.test.ts (21 tests)`, root total **341 passed (341)**. The accepted set is unchanged (`dsh-derived-plugin`, `dsh-fs-tool`, `dsh-hello-plugin`) and the report's `Rejected:` line reads 5.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/fixtures/packuments.json registry/scripts/tests/pipeline.test.ts
@@ -1008,7 +1010,7 @@ Two assertions in the root suite pass for any value the code could produce. `toB
 
 **No mutation step.** These are assertions that cannot fail by construction; the demonstration is that the current form passes against a wrong value, which Step 1 shows without touching production code.
 
-- [ ] **Step 1: Show the current assertions accept a wrong value**
+- [x] **Step 1: Show the current assertions accept a wrong value**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -1018,7 +1020,7 @@ node -e "console.log(['teal','not-a-colour','0.5',' '].map(v => Boolean(v)))"
 
 For the second: `emit([a, b], ...)` with two same-named repo entries returns six artifacts, and `not.toThrow()` inspects none of them — the test named "allows the same bundle name from different repos" would pass if `emit` dropped one of the two entries entirely.
 
-- [ ] **Step 2: Write the assertions that can fail**
+- [x] **Step 2: Write the assertions that can fail**
 
 Replace `registry/scripts/tests/emit.test.ts:353-361` with:
 
@@ -1060,7 +1062,7 @@ Replace `registry/scripts/tests/emit.test.ts:277-282` with:
   })
 ```
 
-- [ ] **Step 3: Verify each fails on the value it now refuses**
+- [x] **Step 3: Verify each fails on the value it now refuses**
 
 ```bash
 cp registry/scripts/src/emit.ts /tmp/emit.ts.h9.orig
@@ -1089,7 +1091,7 @@ cp /tmp/emit.ts.h9.orig registry/scripts/src/emit.ts
 git diff --numstat registry/scripts/src/emit.ts   # must print nothing
 ```
 
-- [ ] **Step 4: Run it green**
+- [x] **Step 4: Run it green**
 
 ```bash
 npx vitest run registry/scripts/tests/emit.test.ts
@@ -1099,7 +1101,7 @@ pnpm typecheck
 
 Expected: PASS — `emit.test.ts (33 tests)`, root total **341 passed (341)** (unchanged: both cases were strengthened in place, none added).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add registry/scripts/tests/emit.test.ts

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -1133,7 +1133,7 @@ entries would also pass if emit dropped one. Both now assert the value."
 
 **No mutation step.** These are absences — modules no test imports and assertions with no failing input. Each step below states the failing form first and confirms it fails.
 
-- [ ] **Step 1: Show the gap**
+- [x] **Step 1: Show the gap**
 
 ```bash
 cd /Evermind/sh_evermind/xuedizhan/dsh-plugin-store
@@ -1150,7 +1150,7 @@ node --experimental-strip-types /tmp/probe-pins.ts
 
 Expected: `pins.constructor is function — !== undefined: true`. `constructor`, `toString` and `valueOf` are all legal npm package names and GitHub bundle names are unrestricted, so `host/index.ts:812`'s `pins[entry.name]` reads a function off `Object.prototype` and reports it as the installed commit with `outdated: true`.
 
-- [ ] **Step 2: Write the tests**
+- [x] **Step 2: Write the tests**
 
 Create `packages/dsh-plugin-shop/tests/host/repo-pins.test.ts`:
 
@@ -1339,7 +1339,7 @@ Replace `packages/dsh-plugin-shop/tests/host/hot.test.ts:270-277` with:
 
 and add `existsSync` to the `node:fs` import on line 2: `import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'`.
 
-- [ ] **Step 3: Verify the new tests fail before the fix**
+- [x] **Step 3: Verify the new tests fail before the fix**
 
 ```bash
 npx vitest run --root packages/dsh-plugin-shop tests/host/repo-pins.test.ts
@@ -1347,7 +1347,7 @@ npx vitest run --root packages/dsh-plugin-shop tests/host/repo-pins.test.ts
 
 Expected: FAIL — `never answers a lookup from Object.prototype` reports `AssertionError: expected [Function: Object] to be undefined`. The other six cases pass (they describe behaviour the module already has, and they are what makes a future regression in the hex filter or the corrupt-file degradation visible at all).
 
-- [ ] **Step 4: Fix the prototype hazard and run everything green**
+- [x] **Step 4: Fix the prototype hazard and run everything green**
 
 In `packages/dsh-plugin-shop/src/host/repo-pins.ts`, replace line 27:
 
@@ -1382,7 +1382,18 @@ The change is to a pure function's internal record and touches no RPC shape, no 
 
 **One finding this task surfaces and does not fix.** `host/index.ts:729` writes `args.version` into the pins file, and for a release-rescued github entry that value is a tag (`v1.0.0` — see `index.test.ts:1000`), which `readRepoPins`'s 40-hex filter drops on the next read. Such an entry therefore falls back to `installed: spec` and can never report `outdated`. That changes an RPC-visible field, so it belongs to plan D beside G-1's identity work, not here. Record it in plan D rather than widening this task.
 
-- [ ] **Step 5: Commit**
+> **Executed 2026-09-05. The plan was stale in four places; what landed differs.**
+>
+> 1. **`repo-pins.test.ts` already existed** — commit `110c500` (*fix(host): preserve release tag pins*, plan D's G-11) created it with four cases: a commit round-trip, a release-tag round-trip, a drop of anything that is neither, and missing/corrupt as no memory. Those cover the plan's fixtures in a different but equivalent form, so only the absent case was added: **the prototype hazard**. Writing the plan's file verbatim would have duplicated four tests and deleted a G-11 regression guard.
+> 2. **The "finding this task does not fix" above is fixed.** `110c500` widened the filter to `COMMIT_SHA.test(pin) || RELEASE_TAG.test(pin)`, so a release-rescued entry's tag now survives the read. Nothing to record in plan D.
+> 3. **The plan's `'dsh-upper': 'A'.repeat(40)` fixture would now be wrong.** `RELEASE_TAG` is `/^[A-Za-z0-9][A-Za-z0-9._+/-]{0,127}$/`, which accepts forty uppercase letters. The fixture asserted that value is dropped; it is kept, correctly.
+> 4. **`normalizeRegistryUrl` was not untested.** `npm-origin.test.ts:270` ("keeps a registry url's path when resolving the probe request, even with no trailing slash") already drove exactly that behaviour end to end through `npmOrigin` — the mutation check found it by failing two tests instead of one. The new block still went in, pinning the two lines directly rather than only through their one caller, but its comment says so instead of claiming the gap the plan asserted.
+>
+> Line numbers had also moved: `repo-pins.ts:27` → `:30`, `hot.test.ts:270-277` → `:342`. The `HOT_DIR` the plan's replacement joins is, in `hot.test.ts`, a file-local **absolute** path (`join(PROFILE, '.dsh-shop')`) and not the module's unexported bare segment; the landed test uses the literal `'.dsh-shop'`.
+>
+> **Mutation-checked, against the plan's "no mutation step".** Every new assertion was proven able to fail: the prototype case failed before the fix; `normalizeRegistryUrl` → identity, `npmGlobal` returning a path outside the CLI package, `cleanHotDir` creating the directory on its way past, `ownVersion` → `'0.0.0'`, and a moved `lib/index.js` each failed exactly the case that names them. Package suite **630 passed (630)** across 28 files, root **762 passed (762)**, both typechecks clean.
+
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/dsh-plugin-shop/tests/host/repo-pins.test.ts \

--- a/packages/dsh-plugin-shop/src/host/repo-pins.ts
+++ b/packages/dsh-plugin-shop/src/host/repo-pins.ts
@@ -27,7 +27,13 @@ export function readRepoPins(fs: RepoPinFs, path: string): RepoPins {
   try {
     const parsed = JSON.parse(fs.read(path)) as unknown
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
-    const out: RepoPins = {}
+    // A null prototype, not `{}`: the lookup key is a catalog entry name,
+    // which is hostile npm/GitHub input, and `constructor`, `toString` and
+    // `valueOf` are all legal package names. On a plain object each of them
+    // reads a function off Object.prototype, so `pins[name] !== undefined` is
+    // true for a package that was never installed and `installed()` reports a
+    // function as the installed commit. Same rule as the stars map.
+    const out: RepoPins = Object.create(null) as RepoPins
     for (const [name, pin] of Object.entries(parsed)) {
       if (typeof pin === 'string' && (COMMIT_SHA.test(pin) || RELEASE_TAG.test(pin))) out[name] = pin
     }

--- a/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
+++ b/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
@@ -141,6 +141,33 @@ function localRegistryEnv(): NodeJS.ProcessEnv {
   return { ...process.env, NO_PROXY: noProxy, no_proxy: noProxy }
 }
 
+/**
+ * When set, a skipped exit-criterion case is a FAILURE rather than a silent
+ * pass.
+ *
+ * Both this file and web-full-flow.e2e.ts probe for a working `dsh` and skip
+ * when they cannot find one. That is right locally — not every machine has the
+ * harness installed — and wrong in CI, where these two files ARE the P1 and P2
+ * exit criteria. Reproduced 2026-09-05: with `dsh` hidden from PATH the run
+ * reported `1 skipped` and **exited 0**, so a green CI run was not evidence
+ * that either criterion had executed.
+ *
+ * plugin.yml sets it, because that workflow installs the harness precisely so
+ * these can run. A machine without `dsh` still skips.
+ */
+const requireE2E = process.env.DSH_SHOP_REQUIRE_E2E === '1'
+
+describe('the P2 exit criterion is allowed to skip only where that is honest', () => {
+  it('has the harness and the browser it needs, when the environment says it must', () => {
+    expect(
+      !requireE2E || (hasDsh && hasChromium),
+      `DSH_SHOP_REQUIRE_E2E=1 but the web flow cannot run (dsh: ${hasDsh}, chromium: `
+        + `${hasChromium}), so the P2 exit criterion would have skipped and the run would `
+        + 'still have exited 0.',
+    ).toBe(true)
+  })
+})
+
 describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
   let catalogServer: CatalogServer | undefined
   let localRegistry: LocalRegistry | undefined

--- a/packages/dsh-plugin-shop/tests/host/dsh-cli.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/dsh-cli.test.ts
@@ -3,6 +3,9 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { delimiter, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { dshCommand, resolveDshScript, type DshCliFs } from '../../src/host/dsh-cli.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('dsh-cli')
 
 // Fixtures over mocks: every case builds a real directory tree and reads it
 // through the same seam production uses, so a resolution bug cannot hide
@@ -18,7 +21,7 @@ const realFs: DshCliFs = {
  * `%APPDATA%\npm\node_modules\@deepseek-ai\dsh`. */
 function npmGlobal(options: { bin?: unknown; entry?: string | null } = {}): { shimDir: string; entry: string } {
   const { bin = { dsh: 'lib/bin.js' }, entry = 'lib/bin.js' } = options
-  const shimDir = mkdtempSync(join(tmpdir(), 'dsh-cli-global-'))
+  const shimDir = mkdtempSync(join(TEMP_ROOT, 'dsh-cli-global-'))
   const packageDir = join(shimDir, 'node_modules', '@deepseek-ai', 'dsh')
   mkdirSync(join(packageDir, 'lib'), { recursive: true })
   writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.1.1-rc.2', bin }))
@@ -90,7 +93,7 @@ describe('resolveDshScript', () => {
     // Under vitest `argv1` is the test runner's entry. Accepting it would
     // spawn `node <vitest cli> plugin --profile …`, so the owner check is
     // what keeps the real-install test honest.
-    const decoy = mkdtempSync(join(tmpdir(), 'dsh-cli-decoy-'))
+    const decoy = mkdtempSync(join(TEMP_ROOT, 'dsh-cli-decoy-'))
     const vitestDir = join(decoy, 'node_modules', 'vitest')
     mkdirSync(vitestDir, { recursive: true })
     writeFileSync(join(vitestDir, 'package.json'), JSON.stringify({ name: 'vitest', bin: { vitest: 'cli.js' } }))
@@ -131,14 +134,14 @@ describe('resolveDshScript', () => {
   it('returns null when nothing on PATH carries the CLI package', () => {
     expect(resolveDshScript(realFs, { argv1: undefined, path: undefined })).toBeNull()
     expect(resolveDshScript(realFs, { argv1: undefined, path: '' })).toBeNull()
-    expect(resolveDshScript(realFs, { argv1: undefined, path: mkdtempSync(join(tmpdir(), 'dsh-cli-empty-')) })).toBeNull()
+    expect(resolveDshScript(realFs, { argv1: undefined, path: mkdtempSync(join(TEMP_ROOT, 'dsh-cli-empty-')) })).toBeNull()
   })
 
   it('survives a malformed manifest rather than throwing', () => {
     // Everything read off disk here is outside our control; a manifest that
     // is not JSON means "not the package we are looking for", and the scan
     // must continue to the next PATH entry.
-    const broken = mkdtempSync(join(tmpdir(), 'dsh-cli-broken-'))
+    const broken = mkdtempSync(join(TEMP_ROOT, 'dsh-cli-broken-'))
     mkdirSync(join(broken, 'node_modules', '@deepseek-ai', 'dsh'), { recursive: true })
     writeFileSync(join(broken, 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), '{ not json')
     const { shimDir, entry } = npmGlobal()

--- a/packages/dsh-plugin-shop/tests/host/dsh-cli.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/dsh-cli.test.ts
@@ -79,7 +79,11 @@ describe('resolveDshScript', () => {
     // whichever one PATH happens to name.
     const { shimDir, entry } = npmGlobal()
     expect(resolveDshScript(realFs, { argv1: entry, path: undefined })).toBe(entry)
-    expect(shimDir).toBeTruthy()
+    // `toBeTruthy()` on an mkdtemp result can never fail (H-9). The claim is
+    // that the answer came from argv1's OWNING package rather than from PATH —
+    // which was not consulted at all here — so assert the resolved entry is the
+    // CLI package's own file inside the fixture tree.
+    expect(entry.startsWith(join(shimDir, 'node_modules', '@deepseek-ai', 'dsh'))).toBe(true)
   })
 
   it('rejects a running script owned by some other package and falls back to PATH', () => {

--- a/packages/dsh-plugin-shop/tests/host/executor.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/executor.test.ts
@@ -4,12 +4,15 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { installFailureDetail, installTimeoutDetail, killTree, lineSink, spawnFailureDetail, startInstall, startUninstall, type InstallStatus } from '../../src/host/executor.ts'
 import type { HotRestartReason } from '../../src/host/hot.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('executor')
 
 // A fixture `dsh` that records its full argv in a marker file and exits with
 // the requested code, proving the executor passes --profile and the pinned
 // spec through: `dsh plugin --profile <p> add <spec>` is `$1 $2 $3 $4 $5`.
 function fixtureDsh(exitCode: number): string {
-  const dir = mkdtempSync(join(tmpdir(), 'dsh-fixture-'))
+  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-'))
   const bin = join(dir, 'dsh')
   writeFileSync(bin, [
     '#!/bin/sh',
@@ -27,7 +30,7 @@ function fixtureDsh(exitCode: number): string {
 // bytes come from the script, not the host, so this reproduces the Windows
 // stream shape while running on Linux or macOS.
 function fixtureDshCrlf(exitCode: number, lines: readonly string[]): string {
-  const dir = mkdtempSync(join(tmpdir(), 'dsh-fixture-crlf-'))
+  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-crlf-'))
   const bin = join(dir, 'dsh')
   const payload = lines.map(line => `${line}\\r\\n`).join('')
   writeFileSync(bin, [
@@ -83,7 +86,7 @@ describe('startInstall', () => {
   })
 
   it('serializes installs into one profile', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-serialize-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-serialize-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, [
       '#!/bin/sh',
@@ -110,7 +113,7 @@ describe('startInstall', () => {
   })
 
   it('caps the log at 200 lines, dropping the oldest', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-cap-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-cap-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, [
       '#!/bin/sh',
@@ -132,7 +135,7 @@ describe('startInstall', () => {
   })
 
   it('surfaces stderr verbatim in the log with the recovery hint on failure', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-stderr-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-stderr-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, [
       '#!/bin/sh',
@@ -192,7 +195,7 @@ describe('startInstall post-install confirm (§7.2 step 6)', () => {
   // reconcile is needed — the fixture dsh exits 0 and the manifest is what
   // the confirm must verify against.
   function confirmHome(bundles: string[]): string {
-    const home = mkdtempSync(join(tmpdir(), 'dsh-confirm-'))
+    const home = mkdtempSync(join(TEMP_ROOT, 'dsh-confirm-'))
     mkdirSync(join(home, 'profiles', 'web'), { recursive: true })
     writeFileSync(
       join(home, 'profiles', 'web', 'package.json'),
@@ -235,7 +238,7 @@ describe('startInstall post-install confirm (§7.2 step 6)', () => {
   it('reports failed, naming the file, when the manifest cannot be read', async () => {
     // A profile dir that does not exist at all — readProfileManifest throws,
     // and the executor must not crash: it reports the same failed outcome.
-    const home = mkdtempSync(join(tmpdir(), 'dsh-confirm-missing-'))
+    const home = mkdtempSync(join(TEMP_ROOT, 'dsh-confirm-missing-'))
     const install = startInstall({
       profile: 'web',
       spec: 'dsh-hello-fixture@1.0.0',
@@ -347,7 +350,7 @@ describe('startUninstall', () => {
 
 describe('startUninstall post-remove confirm', () => {
   function confirmHome(bundles: string[]): string {
-    const home = mkdtempSync(join(tmpdir(), 'dsh-confirm-remove-'))
+    const home = mkdtempSync(join(TEMP_ROOT, 'dsh-confirm-remove-'))
     mkdirSync(join(home, 'profiles', 'web'), { recursive: true })
     writeFileSync(
       join(home, 'profiles', 'web', 'package.json'),
@@ -385,7 +388,7 @@ describe('startUninstall post-remove confirm', () => {
   })
 
   it('reports failed, naming the file, when the manifest cannot be read', async () => {
-    const home = mkdtempSync(join(tmpdir(), 'dsh-confirm-remove-missing-'))
+    const home = mkdtempSync(join(TEMP_ROOT, 'dsh-confirm-remove-missing-'))
     const uninstall = startUninstall({
       profile: 'web',
       name: 'dsh-hello-fixture',
@@ -531,7 +534,7 @@ describe('installFailureDetail', () => {
 
 describe('the install deadline and the process group (F-1)', () => {
   function grandchildDsh(sleepSeconds: number): { bin: string; pidFile: string } {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-grandchild-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-grandchild-'))
     const pidFile = join(dir, 'grandchild.pid')
     const bin = join(dir, 'dsh')
     writeFileSync(bin, [
@@ -562,7 +565,7 @@ describe('the install deadline and the process group (F-1)', () => {
   })
 
   it('stops a command that outlives its deadline and frees the profile queue', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-deadline-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-deadline-'))
     const hung = join(dir, 'dsh')
     writeFileSync(hung, [
       '#!/bin/sh',
@@ -658,7 +661,7 @@ describe('lineSink (F-6)', () => {
 
 describe('startInstall line assembly (F-6)', () => {
   it('reports the whole line when the stream splits it, not the fragment', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-split-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-split-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, [
       '#!/bin/sh',
@@ -676,7 +679,7 @@ describe('startInstall line assembly (F-6)', () => {
   })
 
   it('keeps a final unterminated line in the log', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-unterminated-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-unterminated-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, ['#!/bin/sh', "printf '%s' 'the bundle did not appear'", 'exit 1', ''].join('\n'))
     chmodSync(bin, 0o755)
@@ -744,7 +747,7 @@ describe('spawnFailureDetail', () => {
 
 describe('the child environment (F-12 residual)', () => {
   it('passes the parent environment to the child, deliberately', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-env-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-env-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, ['#!/bin/sh', `printf '%s\n' "$SHOP_F12_PROBE" > "${join(dir, 'env.txt')}"`, 'exit 0', ''].join('\n'))
     chmodSync(bin, 0o755)
@@ -758,7 +761,7 @@ describe('the child environment (F-12 residual)', () => {
   })
 
   it('uses only the given environment when one is passed', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-env-pinned-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-env-pinned-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, ['#!/bin/sh', `printf '%s\n' "$SHOP_F12_PROBE" > "${join(dir, 'env.txt')}"`, 'exit 0', ''].join('\n'))
     chmodSync(bin, 0o755)

--- a/packages/dsh-plugin-shop/tests/host/executor.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/executor.test.ts
@@ -480,6 +480,53 @@ describe('installFailureDetail', () => {
     expect(detail).not.toMatch(/\r/)
   })
 
+
+  it('picks the LAST pnpm error code when a failed install emits several', () => {
+    // "Scanning from the end" is the documented rule, and with two codes it is
+    // the only thing that decides which one a user reads. Both existing
+    // verbatim fixtures carry exactly one diagnostic line, so dropping the
+    // reverse and taking the first match passed (H-3). pnpm emits the peer
+    // warning while resolving and the fetch failure when it gives up: the later
+    // line is the one that ended the install.
+    const log = [
+      '+ dsh-two-codes 1.0.0',
+      '[ERR_PNPM_PEER_DEP_ISSUES] Unmet peer dependencies',
+      'Progress: resolved 12, reused 12, downloaded 0',
+      '[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/dsh-nope: Not Found - 404',
+      'dsh: pnpm failed in profile directory /root/probe/profiles/f7',
+    ]
+    const detail = installFailureDetail('web', log)
+    expect(detail).toMatch(/ERR_PNPM_FETCH_404/)
+    expect(detail).not.toMatch(/ERR_PNPM_PEER_DEP_ISSUES/)
+    // The noise filter still ran: neither the Progress line nor dsh's own
+    // wrapper may be what the user is shown.
+    expect(detail).not.toMatch(/Progress: resolved/)
+    expect(detail).not.toMatch(/pnpm failed in profile directory/)
+    // The approve-builds hint belongs to ERR_PNPM_IGNORED_BUILDS alone.
+    expect(detail).not.toMatch(/approve-builds/)
+  })
+
+  it('prefers a pnpm error code over a thrown error even when the throw came later', () => {
+    // The rule is a precedence, not a position: "a pnpm error code first, then
+    // any thrown error". The TypeError below is LATER in the log than the pnpm
+    // code, so scanning from the end alone would pick it — which is what makes
+    // this able to catch a swap of the two find clauses. pnpm named the actual
+    // failure; dsh's own reconcile then threw over the half-installed profile,
+    // which is a consequence, not the cause.
+    const log = [
+      'Done in 1.2s using pnpm v11.13.0',
+      '[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for dsh-nope@9.9.9',
+      'TypeError: Cannot read properties of undefined (reading \'bundles\')',
+      '    at reconcile (file:///…/dsh-app-boot/lib/index.js:512:9)',
+      'Node.js v26.6.0',
+    ]
+    const detail = installFailureDetail('web', log)
+    expect(detail).toMatch(/ERR_PNPM_NO_MATCHING_VERSION/)
+    expect(detail).toMatch(/dsh-nope@9\.9\.9/)
+    expect(detail).not.toMatch(/TypeError/)
+    expect(detail).not.toMatch(/Node\.js v26/)
+    expect(detail).toMatch(/Run: dsh plugin --profile web install/)
+  })
 })
 
 describe('the install deadline and the process group (F-1)', () => {

--- a/packages/dsh-plugin-shop/tests/host/hot.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/hot.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -339,7 +339,12 @@ describe('cleanHotDir', () => {
   it('is a no-op when the namespace directory does not exist', () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-shop-hot-'))
     try {
-      expect(() => cleanHotDir(join(root, 'profile'))).not.toThrow()
+      const profileDir = join(root, 'profile')
+      cleanHotDir(profileDir)
+      // `not.toThrow()` alone would also pass if cleanHotDir created the
+      // directory on its way past, which is the opposite of a no-op (H-9).
+      expect(existsSync(profileDir)).toBe(false)
+      expect(existsSync(join(profileDir, '.dsh-shop'))).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/dsh-plugin-shop/tests/host/hot.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/hot.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
@@ -8,6 +7,9 @@ import {
   type HotFs,
 } from '../../src/host/hot.ts'
 import { JSON_SCHEMA, load } from 'js-yaml'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('hot')
 
 describe('parseSimplePatch', () => {
   it('parses plain id/name insert rows', () => {
@@ -318,7 +320,7 @@ describe('hotMount / hotUnmount', () => {
 
 describe('cleanHotDir', () => {
   it('wipes only this session\'s hot-<n>.yml files', () => {
-    const root = mkdtempSync(join(tmpdir(), 'dsh-shop-hot-'))
+    const root = mkdtempSync(join(TEMP_ROOT, 'dsh-shop-hot-'))
     try {
       const profileDir = join(root, 'profile')
       const hotDir = join(profileDir, '.dsh-shop')
@@ -337,7 +339,7 @@ describe('cleanHotDir', () => {
   })
 
   it('is a no-op when the namespace directory does not exist', () => {
-    const root = mkdtempSync(join(tmpdir(), 'dsh-shop-hot-'))
+    const root = mkdtempSync(join(TEMP_ROOT, 'dsh-shop-hot-'))
     try {
       const profileDir = join(root, 'profile')
       cleanHotDir(profileDir)

--- a/packages/dsh-plugin-shop/tests/host/index.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/index.test.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createHash } from 'node:crypto'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import ShopGateway, { verifyTarballSha256 } from '../../src/host/index.ts'
@@ -9,6 +8,9 @@ import type { InventoryEntry, LoaderEntryLike, ShopGatewayOptions, ShopInstallSt
 import type { HotMountResult } from '../../src/host/hot.ts'
 import type { CatalogResult, CatalogSnapshot, LoadCatalogOptions } from '../../src/host/catalog.ts'
 import type { CatalogEntry } from '../../src/host/types.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('index')
 
 // The install tests drive the full §7.2 path including the post-install
 // confirm, which re-reads the profile manifest through app-boot's
@@ -16,7 +18,7 @@ import type { CatalogEntry } from '../../src/host/types.ts'
 // profile manifest already lists the bundle the install tests install, so the
 // exit-0 fixture dsh passes the confirm without any dsh reconcile. Each test
 // file runs in its own vitest worker, so the pin never leaves this file.
-const shopHome = mkdtempSync(join(tmpdir(), 'dsh-gateway-home-'))
+const shopHome = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-home-'))
 process.env.DSH_HOME = shopHome
 mkdirSync(join(shopHome, 'profiles', 'web'), { recursive: true })
 writeFileSync(join(shopHome, 'profiles', 'web', 'package.json'), JSON.stringify({ dsh: { profile: { bundles: ['dsh-hello-plugin', 'dsh-repo-plugin', 'sub-plugin', 'dsh-rescued', 'dsh-plugin-shop'] } } }))
@@ -41,7 +43,7 @@ describe('two catalog entries share one name (G-1)', () => {
     const bin = join(dir, 'fake-dsh')
     writeFileSync(bin, ['#!/bin/sh', `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`, 'exit 0', ''].join('\n'))
     chmodSync(bin, 0o755)
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-dup-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(dir, 'cache'), profile: 'web', profileDir,
@@ -51,7 +53,7 @@ describe('two catalog entries share one name (G-1)', () => {
   }
 
   it('spawns the identity that was asked for, not the first entry with the name', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-dup-install-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-install-'))
     const gateway = gatewayWithBoth(dir, {})
     const result = await gateway.install({
       name: 'dsh-foo', version: bobCommit, acknowledged: true,
@@ -73,7 +75,7 @@ describe('two catalog entries share one name (G-1)', () => {
   })
 
   it('refuses a name-only install request while two entries share the name', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-dup-ambiguous-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-ambiguous-'))
     const gateway = gatewayWithBoth(dir, {})
     const result = await gateway.install({ name: 'dsh-foo', version: bobCommit, acknowledged: true })
     expect(result).toMatchObject({ ok: false, code: 'ambiguous-identity' })
@@ -82,7 +84,7 @@ describe('two catalog entries share one name (G-1)', () => {
   })
 
   it('reports one row for the repository that is actually installed', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-dup-installed-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-installed-'))
     mkdirSync(join(dir, 'cache'), { recursive: true })
     writeFileSync(join(dir, 'cache/github-pins.json'), JSON.stringify({ 'github:bob/dsh-foo#': bobCommit }))
     const gateway = gatewayWithBoth(dir, { 'dsh-foo': 'github:bob/dsh-foo' })
@@ -94,8 +96,8 @@ describe('two catalog entries share one name (G-1)', () => {
   })
 
   it('does not let an npm namesake claim a repo entry\'s installed row', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-dup-npm-'))
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-dup-npm-profile-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-npm-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-npm-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
       name: 'dsh-profile-web', dsh: { profile: { bundles: [] } },
       dependencies: { 'dsh-foo': 'github:bob/dsh-foo' },
@@ -115,7 +117,7 @@ describe('two catalog entries share one name (G-1)', () => {
   })
 
   it('forgets the identity pin on uninstall', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-dup-uninstall-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-uninstall-'))
     mkdirSync(join(dir, 'cache'), { recursive: true })
     writeFileSync(join(dir, 'cache/github-pins.json'), JSON.stringify({
       'github:bob/dsh-foo#': bobCommit, 'github:alice/dsh-foo#': aliceCommit,
@@ -150,7 +152,7 @@ function fixturePackage(profileDir: string, name: string, patch: string | null):
 }
 
 function toggleProfile(): string {
-  const profileDir = mkdtempSync(join(tmpdir(), 'dsh-shop-'))
+  const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-shop-'))
   writeFileSync(join(profileDir, 'cordis.yml'), '[]\n')
   writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
   return profileDir
@@ -172,7 +174,7 @@ describe('ShopGateway', () => {
     // so the walk-up from import.meta.url finds the repo, not a profile. The
     // boot's ctx.baseUrl — the profile's cordis.yml directory — is the
     // authoritative source, and the constructor must use it.
-    const home = mkdtempSync(join(tmpdir(), 'dsh-linked-'))
+    const home = mkdtempSync(join(TEMP_ROOT, 'dsh-linked-'))
     const profileDir = join(home, 'profiles', 'web')
     mkdirSync(profileDir, { recursive: true })
     writeFileSync(join(profileDir, 'cordis.yml'), '[]\n')
@@ -199,7 +201,7 @@ describe('ShopGateway', () => {
     // The real pluginInventory service returns a snapshot object, not a bare
     // array — hub-borrowings B assumed the array, and the toggle crashed on
     // the real wire shape (0.5.1 regression fix). Pin the real shape here.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-toggle-snapshot-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-toggle-snapshot-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     fixturePackage(profileDir, 'dsh-hello-fixture', "- insert:\n    - id: snapshot-row\n      name: 'dsh-hello-fixture'\n")
     const gateway = new ShopGateway(stubCtx(), {
@@ -212,7 +214,7 @@ describe('ShopGateway', () => {
   })
 
   it('drops malformed inventory rows instead of crashing', async () => {
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-toggle-malformed-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-toggle-malformed-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     fixturePackage(profileDir, 'dsh-hello-fixture', "- insert:\n    - id: good-row\n      name: 'dsh-hello-fixture'\n")
     const gateway = new ShopGateway(stubCtx(), {
@@ -229,7 +231,7 @@ describe('ShopGateway', () => {
     // The whole point of the check: the mismatch is said once, at load, in the
     // shop's own words — not diagnosed for hours from a path that silently
     // changed behaviour.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-peerversion-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-peerversion-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     const warnings: string[] = []
     const ctx = { get: () => undefined, reflect: { provide: () => {} }, logger: { warn: (m: string) => warnings.push(m) } } as never
@@ -244,7 +246,7 @@ describe('ShopGateway', () => {
 
   it('loads silently when the harness satisfies every declared peer range', async () => {
     // 0.1.2-rc.1 against ^0.1.1-rc.2 is what is installed today: silence.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-peerversion-ok-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-peerversion-ok-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     const warnings: string[] = []
     const ctx = { get: () => undefined, reflect: { provide: () => {} }, logger: { warn: (m: string) => warnings.push(m) } } as never
@@ -261,7 +263,7 @@ describe('ShopGateway', () => {
     // incompatibilityMap) is what covers a missing peer. The resolver here is
     // the real one; only the range table is injected, and it names a package
     // that exists in no store.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-peerversion-absent-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-peerversion-absent-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     const warnings: string[] = []
     const ctx = { get: () => undefined, reflect: { provide: () => {} }, logger: { warn: (m: string) => warnings.push(m) } } as never
@@ -280,7 +282,7 @@ describe('ShopGateway', () => {
     // would. If the harness under this repo ever moves off the declared
     // line, this test failing IS the warning firing — read the message and
     // decide whether the ranges or the install is wrong.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-peerversion-live-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-peerversion-live-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     const warnings: string[] = []
     const ctx = { get: () => undefined, reflect: { provide: () => {} }, logger: { warn: (m: string) => warnings.push(m) } } as never
@@ -368,7 +370,7 @@ describe('ShopGateway.catalog', () => {
 // A fixture `dsh` that records its argv and exits 0; the calls log path lets
 // a rejection's no-spawn property be proven by the file's absence.
 function gatewayWithSnapshot(snapshot: CatalogSnapshot, options: Partial<ShopGatewayOptions> = {}): { gateway: ShopGateway; callsLog: string } {
-  const dir = mkdtempSync(join(tmpdir(), 'dsh-gateway-fixture-'))
+  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-fixture-'))
   const bin = join(dir, 'dsh')
   writeFileSync(bin, [
     '#!/bin/sh',
@@ -379,7 +381,7 @@ function gatewayWithSnapshot(snapshot: CatalogSnapshot, options: Partial<ShopGat
   chmodSync(bin, 0o755)
   // The install flow reads the running profile manifest before spawning (to
   // tell an update from a fresh install); the fixture supplies one.
-  const profileDir = mkdtempSync(join(tmpdir(), 'dsh-gateway-profile-'))
+  const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-profile-'))
   writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
   const gateway = new ShopGateway(stubCtx(), {
     catalogUrl: 'https://shop.test/v1/',
@@ -589,7 +591,7 @@ describe('ShopGateway.installed', () => {
   ]
 
   function gatewayWithManifest(dependencies: Record<string, string>): ShopGateway {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-installed-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-installed-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: '/cache', profile: 'web', profileDir: dir,
@@ -598,7 +600,7 @@ describe('ShopGateway.installed', () => {
   }
 
   it('carries the inventory enabled state onto the installed rows', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-installed-inv-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-installed-inv-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-one': '^1.0.0' } }))
     // The disabled state is read through the ids dsh-one's own bundle patch
     // inserts — the entry's module name is deliberately NOT the package name,
@@ -620,7 +622,7 @@ describe('ShopGateway.installed', () => {
     // `include:one-row`, so matching only the bare id found no live entry and
     // `enabledOf` fell through to its "nothing live, assume enabled" default
     // — a plugin the person had disabled kept rendering with its switch on.
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-installed-inc-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-installed-inc-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-one': '^1.0.0' } }))
     fixturePackage(dir, 'dsh-one', "- insert:\n    - id: one-row\n      name: 'dsh-one/host'\n")
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-one': '^1.0.0' } }))
@@ -655,7 +657,7 @@ describe('ShopGateway.installed', () => {
   })
 
   it('lazily loads the catalog when installed() is called without a prior catalog()', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-installed-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-installed-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-one': '^1.0.0' } }))
     let loadCalls = 0
     const gateway = new ShopGateway(stubCtx(), {
@@ -683,7 +685,7 @@ describe('forwards-only outdated', () => {
   ]
 
   function gatewayWithManifest(dependencies: Record<string, string>): ShopGateway {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-forwards-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-forwards-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: '/cache', profile: 'web', profileDir: dir,
@@ -716,7 +718,7 @@ describe('ShopGateway.uninstall', () => {
   ]
 
   function gatewayWithManifest(dependencies: Record<string, string>): ShopGateway {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-uninstall-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-uninstall-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: '/cache', profile: 'web', profileDir: dir,
@@ -757,13 +759,13 @@ describe('ShopGateway.restart', () => {
   // check passes; the fixture is a harmless echo-exit so no real dsh web is
   // ever spawned by a test.
   function restartingGateway(options: { exit: ReturnType<typeof vi.fn>; cacheDir?: string; restartArgv?: string[] }): ShopGateway {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-gateway-restart-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-restart-'))
     const bin = join(dir, 'dsh')
     writeFileSync(bin, `#!/bin/sh\necho "$1 $2 $3" >> "${join(dir, 'calls.log')}"\nexit 0\n`)
     chmodSync(bin, 0o755)
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/',
-      cacheDir: options.cacheDir ?? mkdtempSync(join(tmpdir(), 'dsh-restart-cache-')),
+      cacheDir: options.cacheDir ?? mkdtempSync(join(TEMP_ROOT, 'dsh-restart-cache-')),
       profile: 'web',
       dshBin: bin,
       restartArgv: options.restartArgv ?? ['web'],
@@ -817,7 +819,7 @@ describe('ShopGateway.restart', () => {
   })
 
   it("re-runs this process's own entry when dshBin is the bare default", async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-node-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-node-'))
     const marker = join(dir, 'ran.log')
     const script = join(dir, 'fake-bin.js')
     writeFileSync(script, `require('node:fs').appendFileSync(${JSON.stringify(marker)}, process.argv.slice(2).join(' ') + '\\n')\n`)
@@ -841,13 +843,13 @@ describe('ShopGateway.restart', () => {
 // inside it before committing. Hot-path cases spread these and add the
 // profile manifest, catalog fixture, and the hot/loader injections.
 function gatewayOptions() {
-  const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-guard-'))
+  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-guard-'))
   const bin = join(dir, 'dsh')
   writeFileSync(bin, `#!/bin/sh\necho "$1 $2 $3" >> "${join(dir, 'calls.log')}"\nexit 0\n`)
   chmodSync(bin, 0o755)
   return {
     catalogUrl: 'https://shop.test/v1/',
-    cacheDir: mkdtempSync(join(tmpdir(), 'dsh-restart-guard-cache-')),
+    cacheDir: mkdtempSync(join(TEMP_ROOT, 'dsh-restart-guard-cache-')),
     profile: 'web',
     exit: () => {}, restartExitDelayMs: 0,
     dshBin: bin,
@@ -964,12 +966,12 @@ describe('ShopGateway.updateStart', () => {
   it('spawns the pinned self-update spec through the executor', async () => {
     // The confirm re-reads the profile manifest for the shop's bundle, so
     // the fixture home must already list it (an update keeps it listed).
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-self-update-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-self-update-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({
       name: 'dsh-profile-web',
       dsh: { profile: { bundles: ['dsh-plugin-shop'] } },
     }))
-    const binDir = mkdtempSync(join(tmpdir(), 'dsh-self-update-bin-'))
+    const binDir = mkdtempSync(join(TEMP_ROOT, 'dsh-self-update-bin-'))
     const bin = join(binDir, 'dsh')
     writeFileSync(bin, [
       '#!/bin/sh',
@@ -1017,7 +1019,7 @@ describe('ShopGateway github entries', () => {
     ].join('\n'))
     chmodSync(bin, 0o755)
     // The install flow reads the running profile manifest before spawning.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-repo-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-repo-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(dir, 'cache'), profile: 'web', profileDir,
@@ -1027,7 +1029,7 @@ describe('ShopGateway github entries', () => {
   }
 
   it('spawns github:owner/slug#commit from snapshot fields and records the pin', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-github-install-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-install-'))
     const gateway = gatewayWithRepo(dir)
     const result = await gateway.install({ name: 'dsh-repo-plugin', version: commit, acknowledged: true })
     expect(result.ok).toBe(true)
@@ -1044,11 +1046,11 @@ describe('ShopGateway github entries', () => {
   })
 
   it('reports a github install by its pin, outdated when the catalog commit moved', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-github-installed-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-installed-'))
     mkdirSync(join(dir, 'cache'), { recursive: true })
     const oldCommit = 'a'.repeat(40)
     writeFileSync(join(dir, 'cache/github-pins.json'), JSON.stringify({ 'dsh-repo-plugin': oldCommit }))
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-github-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-repo-plugin': 'github:someone/dsh-repo-plugin' } }))
     const gateway = new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(dir, 'cache'), profile: 'web', profileDir,
@@ -1059,8 +1061,8 @@ describe('ShopGateway github entries', () => {
   })
 
   it('forgets the pin on uninstall', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-github-uninstall-'))
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-github-profile-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-uninstall-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-profile-'))
     mkdirSync(join(dir, 'cache'), { recursive: true })
     writeFileSync(join(dir, 'cache/github-pins.json'), JSON.stringify({ 'dsh-repo-plugin': commit }))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-repo-plugin': 'github:someone/dsh-repo-plugin' } }))
@@ -1096,7 +1098,7 @@ describe('subpackage install spec', () => {
     ].join('\n'))
     chmodSync(bin, 0o755)
     // The install flow reads the running profile manifest before spawning.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-sub-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-sub-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(dir, 'cache'), profile: 'web', profileDir,
@@ -1106,7 +1108,7 @@ describe('subpackage install spec', () => {
   }
 
   it('spawns github:owner/slug#commit&path:<subdir> and records the pin', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-sub-install-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-sub-install-'))
     const gateway = gatewayWithSub(dir)
     const result = await gateway.install({ name: 'sub-plugin', version: commit, acknowledged: true })
     expect(result.ok).toBe(true)
@@ -1149,7 +1151,7 @@ describe('release-rescued tarball install', () => {
     ].join('\n'))
     chmodSync(bin, 0o755)
     // The install flow reads the running profile manifest before spawning.
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-tarball-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(dir, 'cache'), profile: 'web', profileDir,
@@ -1166,7 +1168,7 @@ describe('release-rescued tarball install', () => {
     // manifest records only `github:owner/slug`, so the pins file is how
     // `installed()` reports outdated honestly).
     const fetchTarball = vi.fn(async () => new Response(tarballBytes))
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-tarball-install-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-install-'))
     const gateway = gatewayWithTarball(dir, fetchTarball)
     const result = await gateway.install({ name: 'dsh-rescued', version: tag, acknowledged: true })
     expect(result.ok).toBe(true)
@@ -1185,7 +1187,7 @@ describe('release-rescued tarball install', () => {
 
   it('rejects tarball-integrity without spawning when the bytes do not match the recorded sha256', async () => {
     const fetchTarball = vi.fn(async () => new Response(new TextEncoder().encode('tampered bytes')))
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-tarball-mismatch-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-mismatch-'))
     const gateway = gatewayWithTarball(dir, fetchTarball)
     const result = await gateway.install({ name: 'dsh-rescued', version: tag, acknowledged: true })
     expect(result).toEqual({
@@ -1201,7 +1203,7 @@ describe('release-rescued tarball install', () => {
 
   it('rejects tarball-integrity with a network-failure detail when the fetch throws', async () => {
     const fetchTarball = vi.fn(async () => { throw new Error('ECONNREFUSED') })
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-tarball-fetchfail-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-fetchfail-'))
     const gateway = gatewayWithTarball(dir, fetchTarball)
     const result = await gateway.install({ name: 'dsh-rescued', version: tag, acknowledged: true })
     expect(result.ok).toBe(false)
@@ -1218,11 +1220,11 @@ describe('release-rescued tarball install', () => {
     const fetchTarball = vi.fn(async () => new Response(tarballBytes))
     // The npm path: the spec is `name@version`, no release asset involved.
     const npmEntry: CatalogEntry = { name: 'dsh-hello-plugin', version: '1.2.0', integrity: null, publishedAt: null, repository: null, license: 'MIT', tier: 'community', metadata: 'derived', source: 'npm', added: '2026-08-25' }
-    const npmDir = mkdtempSync(join(tmpdir(), 'dsh-npm-notarball-'))
+    const npmDir = mkdtempSync(join(TEMP_ROOT, 'dsh-npm-notarball-'))
     const npmBin = join(npmDir, 'fake-dsh')
     writeFileSync(npmBin, ['#!/bin/sh', `echo "$1 $2 $3 $4 $5" >> "${join(npmDir, 'calls.log')}"`, 'exit 0', ''].join('\n'))
     chmodSync(npmBin, 0o755)
-    const npmProfileDir = mkdtempSync(join(tmpdir(), 'dsh-npm-notarball-profile-'))
+    const npmProfileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-npm-notarball-profile-'))
     writeFileSync(join(npmProfileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const npmGateway = new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(npmDir, 'cache'), profile: 'web', profileDir: npmProfileDir,
@@ -1241,11 +1243,11 @@ describe('release-rescued tarball install', () => {
       tier: 'community', metadata: 'declared', source: 'github', repo: 'someone/dsh-repo-plugin',
       added: '2026-08-25',
     }
-    const repoDir = mkdtempSync(join(tmpdir(), 'dsh-github-notarball-'))
+    const repoDir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-notarball-'))
     const repoBin = join(repoDir, 'fake-dsh')
     writeFileSync(repoBin, ['#!/bin/sh', `echo "$1 $2 $3 $4 $5" >> "${join(repoDir, 'calls.log')}"`, 'exit 0', ''].join('\n'))
     chmodSync(repoBin, 0o755)
-    const repoProfileDir = mkdtempSync(join(tmpdir(), 'dsh-github-notarball-profile-'))
+    const repoProfileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-notarball-profile-'))
     writeFileSync(join(repoProfileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const repoGateway = new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: join(repoDir, 'cache'), profile: 'web', profileDir: repoProfileDir,
@@ -1259,10 +1261,10 @@ describe('release-rescued tarball install', () => {
   })
 
   it('reports a release-rescued install as outdated when the catalog tag moves (G-11)', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-tarball-outdated-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-outdated-'))
     mkdirSync(join(dir, 'cache'), { recursive: true })
     writeFileSync(join(dir, 'cache/github-pins.json'), JSON.stringify({ 'github:owner/slug#': 'v1.0.0' }))
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-tarball-outdated-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-outdated-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
       name: 'dsh-profile-web', dsh: { profile: { bundles: [] } },
       dependencies: { 'dsh-rescued': TARBALL_URL },
@@ -1341,7 +1343,7 @@ describe('hot paths — install / uninstall / update through the afterDone seam'
     hot?: ShopGatewayOptions['hot']
     loaderEntries?: ShopGatewayOptions['loaderEntries']
   }): { gateway: ShopGateway; profileDir: string } {
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-hot-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-hot-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
       name: 'dsh-profile-web',
       dsh: { profile: { bundles: [] } },
@@ -1748,7 +1750,7 @@ describe('concurrent catalog loads (G-7)', () => {
   }]
 
   it('loads once when catalog() and installed() are called together on a cold cache', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-once-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-once-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: { 'dsh-one': '^1.0.0' } }))
     let loadCalls = 0
     let release!: () => void
@@ -1770,7 +1772,7 @@ describe('concurrent catalog loads (G-7)', () => {
   })
 
   it('still re-asks the loader after a failed load', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-once-fail-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-once-fail-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     let loadCalls = 0
     const gateway = new ShopGateway(stubCtx(), {
@@ -1787,7 +1789,7 @@ describe('concurrent catalog loads (G-7)', () => {
   })
 
   it('a refresh always reaches the loader', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-once-refresh-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-once-refresh-'))
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const seen: Array<boolean | undefined> = []
     const gateway = new ShopGateway(stubCtx(), {
@@ -1808,11 +1810,11 @@ describe('restart while an install is running (F-5)', () => {
     // A command that is still rewriting the profile owns the profile for the
     // duration of the operation. Restart must leave both that child and the
     // serving process alone until it has settled.
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-busy-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-busy-'))
     const slow = join(dir, 'dsh')
     writeFileSync(slow, ['#!/bin/sh', 'sleep 2', 'exit 0', ''].join('\n'))
     chmodSync(slow, 0o755)
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-restart-busy-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-busy-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const listed: CatalogEntry = {
       name: 'dsh-hello-plugin', version: '1.2.0', integrity: null, publishedAt: null, repository: null,
@@ -1820,7 +1822,7 @@ describe('restart while an install is running (F-5)', () => {
     }
     const exit = vi.fn()
     const gateway = new ShopGateway(stubCtx(), {
-      catalogUrl: 'https://shop.test/v1/', cacheDir: mkdtempSync(join(tmpdir(), 'dsh-restart-busy-cache-')),
+      catalogUrl: 'https://shop.test/v1/', cacheDir: mkdtempSync(join(TEMP_ROOT, 'dsh-restart-busy-cache-')),
       profile: 'web', profileDir, dshBin: slow, exit, restartArgv: ['web'],
       // A dead pid lets the pre-fix helper run without waiting for this test
       // worker; the failing assertion is the returned restart outcome.
@@ -1844,11 +1846,11 @@ describe('restart while an install is running (F-5)', () => {
   })
 
   it('allows the restart once the install has settled', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-idle-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-idle-'))
     const quick = join(dir, 'dsh')
     writeFileSync(quick, ['#!/bin/sh', 'exit 0', ''].join('\n'))
     chmodSync(quick, 0o755)
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-restart-idle-profile-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-idle-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: ['dsh-hello-plugin'] } }, dependencies: {} }))
     const listed: CatalogEntry = {
       name: 'dsh-hello-plugin', version: '1.2.0', integrity: null, publishedAt: null, repository: null,
@@ -1856,7 +1858,7 @@ describe('restart while an install is running (F-5)', () => {
     }
     const exit = vi.fn()
     const gateway = new ShopGateway(stubCtx(), {
-      catalogUrl: 'https://shop.test/v1/', cacheDir: mkdtempSync(join(tmpdir(), 'dsh-restart-idle-cache-')),
+      catalogUrl: 'https://shop.test/v1/', cacheDir: mkdtempSync(join(TEMP_ROOT, 'dsh-restart-idle-cache-')),
       profile: 'web', profileDir, dshBin: quick, exit, restartArgv: ['web'],
       restartExitDelayMs: 1, restartParentPid: 1,
       loadCatalog: async () => ({ snapshot: { schemaVersion: 6, builtAt: '', entries: [listed], denied: [], stars: {} }, stale: false }) as CatalogResult,

--- a/packages/dsh-plugin-shop/tests/host/npm-origin.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/npm-origin.test.ts
@@ -4,7 +4,7 @@ import { gzipSync } from 'node:zlib'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { TransportError } from '../../src/host/origin.ts'
-import { MAX_INFLATED_BYTES, MAX_PACKAGE_BYTES, npmOrigin } from '../../src/host/npm-origin.ts'
+import { MAX_INFLATED_BYTES, MAX_PACKAGE_BYTES, normalizeRegistryUrl, npmOrigin } from '../../src/host/npm-origin.ts'
 
 /** The same real `npm pack` output Task 1 uses. Its inner paths are
  * package/v1/index.json and package/v1/plugins.abc.json. */
@@ -309,5 +309,30 @@ describe('npmOrigin body bounds (F-2 / G-10)', () => {
   it('caps a package tarball at 32 MiB on the wire and 64 MiB inflated', () => {
     expect(MAX_PACKAGE_BYTES).toBe(32 * 1024 * 1024)
     expect(MAX_INFLATED_BYTES).toBe(64 * 1024 * 1024)
+  })
+})
+
+describe('normalizeRegistryUrl', () => {
+  it('appends the trailing slash a path-prefixed registry needs to keep its prefix', () => {
+    // `new URL(path, base)` drops the base's last segment when the base has no
+    // trailing slash: without this, a ~/.npmrc `registry=https://host/npm`
+    // resolves the probe to https://host/dsh-x/latest — off its own prefix, at
+    // a path the operator never served. The probe case above ("keeps a
+    // registry url's path…") already covers that end to end; this pins the two
+    // lines themselves, so a caller that reaches them by another route — the
+    // origin id, a second probe — inherits a tested contract rather than a
+    // property proven only through npmOrigin.
+    expect(normalizeRegistryUrl('https://registry.example.com/npm')).toBe('https://registry.example.com/npm/')
+    expect(new URL('dsh-x/latest', normalizeRegistryUrl('https://registry.example.com/npm')).href)
+      .toBe('https://registry.example.com/npm/dsh-x/latest')
+  })
+
+  it('leaves a url that already ends in a slash alone', () => {
+    expect(normalizeRegistryUrl('https://registry.npmjs.org/')).toBe('https://registry.npmjs.org/')
+    // Idempotent: the origin id is `npm:${registryUrl}` and the race
+    // deduplicates on it, so two spellings of one registry must not race
+    // against each other.
+    expect(normalizeRegistryUrl(normalizeRegistryUrl('https://registry.npmjs.org')))
+      .toBe(normalizeRegistryUrl('https://registry.npmjs.org'))
   })
 })

--- a/packages/dsh-plugin-shop/tests/host/own-version.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/own-version.test.ts
@@ -1,0 +1,43 @@
+/** `ownVersion()` is what the self-update check compares against
+ * `dist-tags.latest` and what the client prints in the version row. It reads
+ * `../package.json` relative to its OWN module url, and its correctness rests
+ * on a layout claim in its header comment: the source tree and the bundled
+ * `lib/index.js` both sit exactly one level below the package root, so the
+ * same relative url resolves in both. Nothing tested either half (audit H-9),
+ * and every 0.5.x release broke on an untested assumption of exactly this
+ * kind.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { ownVersion } from '../../src/own-version.ts'
+
+const packageRoot = join(import.meta.dirname, '..', '..')
+
+function manifest(): { version: string; main: string } {
+  return JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as { version: string; main: string }
+}
+
+describe('ownVersion', () => {
+  it('reports the version in the package that ships it', () => {
+    expect(ownVersion()).toBe(manifest().version)
+    // A semver, not a path or an empty string: the self-update comparison
+    // feeds this to a semver compare, and a non-version silently disables the
+    // check rather than failing it.
+    expect(ownVersion()).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+  })
+
+  it('is one directory below the package root in both trees the module claims', () => {
+    // The claim: `new URL('../package.json', import.meta.url)` resolves for
+    // src/own-version.ts AND for lib/index.js. The first half is proven by the
+    // case above; this pins the second, which a bundler layout change
+    // (lib/host/index.js, say) would break at a user's boot and at no other
+    // time. `pnpm test` and `pnpm typecheck` both run tsdown first, so lib/ is
+    // present here — a bare `vitest run` after `rm -rf lib` is the one way to
+    // see this fail without a real defect.
+    expect(existsSync(join(packageRoot, 'src', 'own-version.ts'))).toBe(true)
+    expect(existsSync(join(packageRoot, 'lib', 'index.js')), 'run tsdown: lib/ is a build output').toBe(true)
+    expect(manifest().main).toBe('lib/index.js')
+  })
+})

--- a/packages/dsh-plugin-shop/tests/host/peers.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/peers.test.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
@@ -13,6 +12,9 @@ import {
   type PeerVersionResolver,
 } from '../../src/host/peers.ts'
 import { ownPeerRanges } from '../../src/own-version.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('peers')
 
 // The real division on the machine where this broke: everything the harness
 // ships resolves from the profile anchor; dsh-client-store, which exists only
@@ -126,7 +128,7 @@ describe('nodeResolver', () => {
   })
 
   it('treats a package that restricts ./package.json as present', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'noderesolver-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'noderesolver-'))
     try {
       // Create a package with exports that do not list "./package.json"
       const pkgDir = join(dir, 'node_modules', 'restricted-pkg')
@@ -153,7 +155,7 @@ describe('nodeResolver', () => {
   })
 
   it("keeps a genuinely missing sibling's verdict beside a restricted package", () => {
-    const dir = mkdtempSync(join(tmpdir(), 'noderesolver-pair-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'noderesolver-pair-'))
     try {
       const pkgDir = join(dir, 'node_modules', 'restricted-pkg')
       mkdirSync(pkgDir, { recursive: true })
@@ -173,7 +175,7 @@ describe('nodeResolver', () => {
   })
 
   it('still throws for a resolution failure that is neither of those', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'noderesolver-invalid-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'noderesolver-invalid-'))
     try {
       const pkgDir = join(dir, 'node_modules', 'invalid-pkg')
       mkdirSync(pkgDir, { recursive: true })
@@ -188,7 +190,7 @@ describe('nodeResolver', () => {
   })
 
   it('still returns false for genuinely missing packages in the same directory', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'noderesolver-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'noderesolver-'))
     try {
       const resolveHere = nodeResolver(pathToFileURL(join(dir, 'anchor.js')).href)
 
@@ -374,7 +376,7 @@ describe('createPeerVersionCheck', () => {
 
 describe('nodeVersionResolver', () => {
   it('reads the version out of a resolvable package manifest', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'peerversion-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'peerversion-'))
     try {
       const pkgDir = join(dir, 'node_modules', 'versioned-pkg')
       mkdirSync(pkgDir, { recursive: true })
@@ -387,7 +389,7 @@ describe('nodeVersionResolver', () => {
   })
 
   it('answers null for a package that is not installed', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'peerversion-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'peerversion-'))
     try {
       const resolveHere = nodeVersionResolver(pathToFileURL(join(dir, 'anchor.js')).href)
       expect(resolveHere('genuinely-missing-pkg')).toBeNull()
@@ -400,7 +402,7 @@ describe('nodeVersionResolver', () => {
     // nodeResolver rethrows here because `false` would be an accusation of
     // absence; there is no version to read either way, and null already means
     // no verdict, so this resolver simply answers null.
-    const dir = mkdtempSync(join(tmpdir(), 'peerversion-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'peerversion-'))
     try {
       const pkgDir = join(dir, 'node_modules', 'restricted-pkg')
       mkdirSync(pkgDir, { recursive: true })
@@ -417,7 +419,7 @@ describe('nodeVersionResolver', () => {
   })
 
   it('answers null for a manifest that declares no version', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'peerversion-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'peerversion-'))
     try {
       const pkgDir = join(dir, 'node_modules', 'unversioned-pkg')
       mkdirSync(pkgDir, { recursive: true })

--- a/packages/dsh-plugin-shop/tests/host/profile.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/profile.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, symlinkSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { discoverProfile, ownedEntryIds, ownsEntryId, setUserLayerRow, setUserLayerRows } from '../../src/host/profile.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('profile')
 
 function fixtureProfile(): string {
-  const home = mkdtempSync(join(tmpdir(), 'dsh-profile-'))
+  const home = mkdtempSync(join(TEMP_ROOT, 'dsh-profile-'))
   const dir = join(home, 'profiles', 'web')
   mkdirSync(dir, { recursive: true })
   writeFileSync(join(dir, 'cordis.yml'), '[]\n')
@@ -31,20 +33,20 @@ describe('discoverProfile', () => {
     // ancestor of the module path is a profile; the boot's ctx.baseUrl (the
     // profile's cordis.yml directory) is the authoritative fallback.
     const dir = fixtureProfile()
-    const linkedSource = mkdtempSync(join(tmpdir(), 'dsh-linked-source-'))
+    const linkedSource = mkdtempSync(join(TEMP_ROOT, 'dsh-linked-source-'))
     expect(discoverProfile(join(linkedSource, 'packages', 'dsh-plugin-shop', 'lib', 'index.js'), dir))
       .toEqual({ name: 'web', dir })
   })
 
   it('ignores a base directory that is not a profile and walks up as before', () => {
     const dir = fixtureProfile()
-    const stray = mkdtempSync(join(tmpdir(), 'dsh-stray-'))
+    const stray = mkdtempSync(join(TEMP_ROOT, 'dsh-stray-'))
     expect(discoverProfile(join(dir, 'node_modules', 'dsh-plugin-shop', 'lib', 'index.js'), stray))
       .toEqual({ name: 'web', dir })
   })
 
   it('throws when no ancestor is a profile directory and no base directory is given', () => {
-    const stray = mkdtempSync(join(tmpdir(), 'dsh-stray-'))
+    const stray = mkdtempSync(join(TEMP_ROOT, 'dsh-stray-'))
     expect(() => discoverProfile(join(stray, 'x.js'))).toThrow(/no profile directory/)
   })
 })
@@ -166,7 +168,7 @@ describe('setUserLayerRows', () => {
 
 describe('setUserLayerRows and the !!js spelling (F-9)', () => {
   it('writes an existing !!js scalar back as !!js, not as __jsExpr', () => {
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-jsexpr-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-jsexpr-'))
     writeFileSync(join(profileDir, 'cordis.patch.yml'), [
       '- id: provider-row',
       '  config:',
@@ -184,7 +186,7 @@ describe('setUserLayerRows and the !!js spelling (F-9)', () => {
   })
 
   it('still writes a plain row unchanged', () => {
-    const profileDir = mkdtempSync(join(tmpdir(), 'dsh-jsexpr-plain-'))
+    const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-jsexpr-plain-'))
     setUserLayerRows({ profileDir, rows: [{ id: 'a', disabled: true }, { id: 'b', disabled: false }] })
     expect(readFileSync(join(profileDir, 'cordis.patch.yml'), 'utf8')).toBe('- id: a\n  disabled: true\n')
     rmSync(profileDir, { recursive: true, force: true })

--- a/packages/dsh-plugin-shop/tests/host/real-install.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/real-install.test.ts
@@ -46,7 +46,35 @@ const hasDsh = (() => {
   }
 })()
 
+/**
+ * When set, a skipped exit-criterion case is a FAILURE rather than a silent
+ * pass.
+ *
+ * Both this file and web-full-flow.e2e.ts probe for a working `dsh` and skip
+ * when they cannot find one. That is right locally — not every machine has the
+ * harness installed — and wrong in CI, where these two files ARE the P1 and P2
+ * exit criteria. Reproduced 2026-09-05: with `dsh` hidden from PATH the run
+ * reported `1 skipped` and **exited 0**, so a green CI run was not evidence
+ * that either criterion had executed.
+ *
+ * plugin.yml sets it, because that workflow installs the harness precisely so
+ * these can run. A machine without `dsh` still skips.
+ */
+const requireE2E = process.env.DSH_SHOP_REQUIRE_E2E === '1'
+
 describe('real installation', () => {
+  it('has the harness it needs, when the environment says it must', () => {
+    // Not `skipIf`: the whole point is that this one cannot be skipped. It is
+    // the guard that turns "the exit criterion did not run" from a silent
+    // pass into a red build.
+    expect(
+      !requireE2E || hasDsh,
+      'DSH_SHOP_REQUIRE_E2E=1 but no usable `dsh` was found, so the exit-criterion '
+        + 'case below would have skipped and the run would still have exited 0. '
+        + 'Either install the harness or unset the variable.',
+    ).toBe(true)
+  })
+
   const tmpHome = mkdtempSync(join(tmpdir(), 'dsh-home-'))
   const fixtureDir = fileURLToPath(new URL('../fixtures/hello-packages/dsh-plugin-shop', import.meta.url))
 

--- a/packages/dsh-plugin-shop/tests/host/real-install.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/real-install.test.ts
@@ -9,11 +9,13 @@
 import { afterAll, describe, expect, it } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { startInstall } from '../../src/host/executor.ts'
 import { dshCommand, resolveDshScript } from '../../src/host/dsh-cli.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('real-install')
 
 // The test needs the real dsh CLI installed. CI installs it in
 // .github/workflows/plugin.yml; the skip fires only on machines that never
@@ -75,7 +77,7 @@ describe('real installation', () => {
     ).toBe(true)
   })
 
-  const tmpHome = mkdtempSync(join(tmpdir(), 'dsh-home-'))
+  const tmpHome = mkdtempSync(join(TEMP_ROOT, 'dsh-home-'))
   const fixtureDir = fileURLToPath(new URL('../fixtures/hello-packages/dsh-plugin-shop', import.meta.url))
 
   afterAll(() => {

--- a/packages/dsh-plugin-shop/tests/host/repo-pins.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/repo-pins.test.ts
@@ -41,6 +41,23 @@ describe('readRepoPins', () => {
     expect(readRepoPins(fs, '/pins.json')).toEqual({ good: commit })
   })
 
+  it('never answers a lookup from Object.prototype', () => {
+    // The lookup key is a catalog entry name — hostile npm/GitHub input — and
+    // `constructor`, `toString` and `valueOf` are all legal npm package names,
+    // while a GitHub bundle name is unrestricted. On a prototype-bearing
+    // record each of them reads a FUNCTION, which `pins[entry.name] !==
+    // undefined` accepts as a recorded pin: host/index.ts then reports a
+    // function as the installed commit, with outdated: true, for a package
+    // that was never installed.
+    const fs = memFs()
+    fs.files.set('/pins.json', JSON.stringify({ 'dsh-real': commit }))
+    const pins = readRepoPins(fs, '/pins.json')
+    for (const inherited of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__']) {
+      expect(pins[inherited], `${inherited} answered a lookup`).toBeUndefined()
+    }
+    expect(pins['dsh-real']).toBe(commit)
+  })
+
   it('reads a missing or corrupt file as no memory', () => {
     const fs = memFs()
     expect(readRepoPins(fs, '/pins.json')).toEqual({})

--- a/packages/dsh-plugin-shop/tests/host/restart.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/restart.test.ts
@@ -4,12 +4,15 @@ import { spawn } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { restartCommand, startRestart } from '../../src/host/restart.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('restart')
 
 // A fixture `dsh` that records its argv in a marker file when it finally
 // runs — the marker's appearance is the proof the helper waited for the
 // parent pid and then exec'd the command.
 function fixtureDsh(marker: string): string {
-  const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-bin-'))
+  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-bin-'))
   const bin = join(dir, 'dsh')
   writeFileSync(bin, [
     '#!/bin/sh',
@@ -39,7 +42,7 @@ async function deadPid(): Promise<number> {
 
 describe('startRestart', () => {
   it('execs the dsh command verbatim once the parent pid is gone, logging its output', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-case-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-case-'))
     const marker = join(dir, 'calls.log')
     const logFile = join(dir, 'restart.log')
     startRestart({
@@ -56,7 +59,7 @@ describe('startRestart', () => {
   })
 
   it('holds the child back while the parent pid is alive', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-case-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-case-'))
     const marker = join(dir, 'calls.log')
     const sleeper = spawn('sh', ['-c', 'exec sleep 10'])
     startRestart({
@@ -118,7 +121,7 @@ describe('restart helper startup failure', () => {
     // An empty PATH makes the helper's `sh` lookup fail asynchronously. The
     // failure must be diagnosable in the handoff log after this function has
     // already returned to its caller.
-    const dir = mkdtempSync(join(tmpdir(), 'dsh-restart-nopath-'))
+    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-nopath-'))
     const logFile = join(dir, 'restart.log')
     startRestart({
       command: 'dsh',

--- a/packages/dsh-plugin-shop/tests/host/temp-root.ts
+++ b/packages/dsh-plugin-shop/tests/host/temp-root.ts
@@ -1,0 +1,38 @@
+/** One temporary root per test file, removed when that file finishes.
+ *
+ * The host tests build a DSH_HOME, a profile or a fake CLI tree per scenario:
+ * 101 `mkdtempSync` calls against 12 removals, which left 203 directories
+ * behind on every run and 8,878 in /tmp by the time it was measured (audit
+ * H-11). Paired `rmSync` calls did not hold, and could not: a scenario that
+ * throws never reaches its own cleanup, and a new scenario copied from an old
+ * one inherits the creation and not the removal.
+ *
+ * One root per file has neither failure mode. `afterAll` runs whether the
+ * file's tests passed, failed or threw, and a scenario added later lands
+ * under the root without anyone remembering to remove it. Scenarios that
+ * already clean up eagerly may keep doing so — the root is a backstop, not a
+ * replacement.
+ *
+ * `tests/temp-dir-leak.test.ts` runs this directory under an isolated TMPDIR
+ * and fails if anything `dsh-` prefixed outlives the run.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll } from 'vitest'
+
+/**
+ * Call at module scope of a test file — `afterAll` has to be registered
+ * during collection, so a call from inside an `it` would be too late.
+ *
+ * @param label names the file in the directory, so a leak that escapes the
+ * root is still attributable.
+ */
+export function fileTempRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `dsh-testrun-${label}-`))
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+  return root
+}

--- a/packages/dsh-plugin-shop/tests/host/transport-parity.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/transport-parity.test.ts
@@ -12,12 +12,14 @@ import { createHash } from 'node:crypto'
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from 'node:fs'
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { loadCatalog, type CatalogFs } from '../../src/host/catalog.ts'
 import { httpOrigin } from '../../src/host/origin.ts'
 import { npmOrigin } from '../../src/host/npm-origin.ts'
 import { startNpmRegistry, type NpmRegistryFixture } from '../fixtures/npm-registry.ts'
+import { fileTempRoot } from './temp-root.ts'
+
+const TEMP_ROOT = fileTempRoot('transport-parity')
 
 const PKG = 'dsh-plugin-shop-catalog-parity'
 const VERSION = '2026.901.0'
@@ -66,7 +68,7 @@ beforeAll(async () => {
   pagesUrl = `http://127.0.0.1:${(pagesServer.address() as AddressInfo).port}/v1/`
 
   // The npm transport: the SAME three files, packed by npm itself.
-  workDir = mkdtempSync(join(tmpdir(), 'shop-parity-'))
+  workDir = mkdtempSync(join(TEMP_ROOT, 'shop-parity-'))
   mkdirSync(join(workDir, 'v1'), { recursive: true })
   writeFileSync(join(workDir, 'v1', 'index.json'), indexText)
   writeFileSync(join(workDir, 'v1', pluginsName), pluginsText)

--- a/packages/dsh-plugin-shop/tests/temp-dir-leak.test.ts
+++ b/packages/dsh-plugin-shop/tests/temp-dir-leak.test.ts
@@ -1,0 +1,50 @@
+/** The host suite builds a DSH_HOME or a profile directory per scenario and
+ * used to remove almost none of them: 102 `mkdtempSync` sites against 12
+ * removals, 204 directories left behind per run, and 8,878 sitting in /tmp
+ * when this was written (audit H-11). The cost is inodes and directory
+ * entries rather than disk — each is nearly empty — but it makes an unrelated
+ * `ls /tmp` useless and it grows with every CI run.
+ *
+ * This file lives at `tests/`, not `tests/host/`, on purpose: it runs the
+ * host directory in a child process, and a guard inside that directory would
+ * spawn itself.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+
+describe('the host suite leaves no temporary directory behind', () => {
+  it('creates nothing under its own TMPDIR that outlives the run', () => {
+    // An isolated TMPDIR rather than a count of /tmp: `os.tmpdir()` reads
+    // TMPDIR first on POSIX, so every scenario's directory lands here and
+    // nowhere else. Counting /tmp directly would race with any other suite on
+    // the machine and would inherit whatever backlog was already there.
+    const sandbox = mkdtempSync(join(tmpdir(), 'dsh-tmp-guard-'))
+    try {
+      // Vitest's own worker variables are stripped: inherited, they make the
+      // nested run believe it is a worker of THIS one and it exits non-zero
+      // before running anything, which would turn this guard green for a
+      // reason that has nothing to do with temporary directories.
+      const env = Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => !key.startsWith('VITEST')),
+      )
+      execFileSync('npx', ['vitest', 'run', 'tests/host/'], {
+        cwd: packageRoot,
+        stdio: 'ignore',
+        env: { ...env, TMPDIR: sandbox },
+      })
+      // `dsh-` only: node drops its own `node-compile-cache` here too, and
+      // that is not ours to account for.
+      const left = readdirSync(sandbox).filter(name => name.startsWith('dsh-'))
+      expect(left, `${left.length} directories outlived the host suite`).toEqual([])
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true })
+    }
+  }, 300_000)
+})

--- a/registry/scripts/src/emit.ts
+++ b/registry/scripts/src/emit.ts
@@ -299,10 +299,14 @@ export function emit(
   ]
   const report = `${lines.join('\n')}\n`
 
-  // E12: the pointer's count must equal the data file's plugin array — the
-  // two artifacts are built separately and this keeps them honest.
-  const dataCount = (JSON.parse(pluginsJson) as { plugins: unknown[] }).plugins.length
-  if (dataCount !== sorted.length) throw new Error('catalog invariant: index count does not match the data file')
+  // E12 -- the pointer's count must equal the data file's plugin array -- used
+  // to be checked here by parsing `pluginsJson` back and comparing lengths.
+  // That throw could not fire: `pluginsJson` is built from `sorted` a few lines
+  // up, and `JSON.stringify` cannot change an array's length, so both numbers
+  // came from the same array by construction. An unreachable throw is a guard
+  // no test can verify. The property is real and worth keeping, so it moved to
+  // emit.test.ts, where it compares the emitted index against the emitted data
+  // file and goes red the day someone builds the two from different sources.
 
   return { pluginsFileName, pluginsJson, indexJson, badgeJson, manifestLock, report }
 }

--- a/registry/scripts/tests/cwd-independence.test.ts
+++ b/registry/scripts/tests/cwd-independence.test.ts
@@ -1,0 +1,46 @@
+/** No test may read a fixture through a cwd-relative path.
+ *
+ * `pipeline.test.ts` opened `registry/scripts/tests/fixtures/packuments.json`
+ * relative to the working directory, so the suite passed or failed on where it
+ * was invoked from — reproduced before the fix: running it from `/tmp` with an
+ * explicit `--root` raised `ENOENT`, and the file reported "no tests" rather
+ * than a failure, which is the shape that hides.
+ *
+ * The rule is enforced over the source rather than by running each file from a
+ * different directory: that would double the suite's runtime to catch a defect
+ * whose signature is one regex. */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const testsDir = dirname(fileURLToPath(import.meta.url))
+
+/** Every `readFileSync`/`readFile` whose first argument is a bare string
+ * literal — the spelling that resolves against the cwd. A path built from
+ * `join(...)`, `import.meta.dirname` or a variable is not matched, because
+ * those are how a module-relative path is written. */
+const CWD_RELATIVE_READ = /\breadFile(?:Sync)?\(\s*'(?!\/)[^']*'/
+
+describe('fixtures resolve from the module, not the working directory', () => {
+  const files = readdirSync(testsDir).filter(f => f.endsWith('.test.ts')).sort()
+
+  it('scans the suite at all, so the check cannot pass by matching nothing', () => {
+    expect(files.length).toBeGreaterThan(20)
+  })
+
+  it('finds no cwd-relative fixture read in any test file', () => {
+    for (const file of files) {
+      const source = readFileSync(join(testsDir, file), 'utf8')
+      for (const [index, line] of source.split('\n').entries()) {
+        expect(
+          CWD_RELATIVE_READ.test(line),
+          `${file}:${index + 1} reads a path relative to the working directory, so this `
+            + `suite passes or fails on where it was invoked from. Resolve it from the module: `
+            + `join(dirname(fileURLToPath(import.meta.url)), …). Line: ${line.trim()}`,
+        ).toBe(false)
+      }
+    }
+  })
+})

--- a/registry/scripts/tests/emit.test.ts
+++ b/registry/scripts/tests/emit.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 import { CATALOG_SCHEMA_VERSION, SUBPACKAGE_SCHEMA_VERSION, emit, SCHEMA_VERSION } from '../src/emit.ts'
 import type { Entry } from '../src/types.ts'
@@ -71,12 +72,25 @@ describe('emit', () => {
     expect(JSON.parse(indexJson)).toMatchObject({ builtAt: '2026-08-18T00:00:00.000Z', count: 1, rejected: 1 })
   })
 
-  it('names the plugins file by the hash of its content', () => {
+  it('names the plugins file by the hash of the bytes it actually writes', () => {
+    // Recomputed from pluginsJson, NOT read back out of the index. The old
+    // version asserted `pluginsFileName === plugins.${index.plugins.sha256}
+    // .json`, and both sides came from the same variable inside emit — so
+    // hashing bytes OTHER than the ones written left the whole suite green.
+    // Proven by mutation: replacing `update(pluginsJson)` with
+    // `update(JSON.stringify(sorted))` — the same data, a different
+    // serialisation — passed 38 of 38.
+    //
+    // What that costs downstream is the reason this matters: the host verifies
+    // the data file against this hash (packages/dsh-plugin-shop/src/host/
+    // catalog.ts), so a hash over the wrong bytes makes every published
+    // catalog unloadable while CI reports success.
     const { pluginsFileName, pluginsJson, indexJson } = emit([entry('dsh-a')], [], '2026-08-18T00:00:00.000Z')
+    const actual = createHash('sha256').update(pluginsJson).digest('hex')
+    expect(pluginsFileName).toBe(`plugins.${actual}.json`)
     const index = JSON.parse(indexJson) as { plugins: { url: string; sha256: string } }
-    expect(pluginsFileName).toBe(`plugins.${index.plugins.sha256}.json`)
+    expect(index.plugins.sha256).toBe(actual)
     expect(index.plugins.url).toBe(pluginsFileName)
-    expect(pluginsJson.length).toBeGreaterThan(0)
   })
 
   it('changes the hash when an entry changes', () => {
@@ -456,3 +470,22 @@ describe('the sorts key on the whole identity, not the name', () => {
     expect(parsed.denied.map(d => d.detail)).toEqual(['aaa', 'zzz'])
   })
 })
+
+describe('the index and the data file describe the same catalog', () => {
+  it('reports a count equal to the data file it points at', () => {
+    // emit.ts used to assert this by parsing pluginsJson back and comparing
+    // lengths -- a throw that could not fire, because both numbers came from
+    // the same `sorted` array a few lines apart and JSON.stringify cannot
+    // change an array's length. The property is real; the guard was not. Here
+    // the two sides are the two EMITTED artifacts, so it goes red the day
+    // someone builds them from different sources.
+    const { indexJson, pluginsJson } = emit(
+      [entry('dsh-a'), entry('dsh-b'), entry('dsh-c')], [], '2026-08-18T00:00:00.000Z',
+    )
+    const index = JSON.parse(indexJson) as { count: number }
+    const data = JSON.parse(pluginsJson) as { plugins: unknown[] }
+    expect(index.count).toBe(data.plugins.length)
+    expect(index.count).toBe(3)
+  })
+})
+

--- a/registry/scripts/tests/emit.test.ts
+++ b/registry/scripts/tests/emit.test.ts
@@ -337,7 +337,15 @@ describe('assertCatalogInvariants', () => {
     // the registry legitimately holds distinct plugins under one name
     const a = repoEntry('dsh-a', 'owner-a/slug')
     const b = repoEntry('dsh-a', 'owner-b/slug')
-    expect(() => emit([a, b], [], '2026-08-31T00:00:00Z')).not.toThrow()
+    const { plugins } = JSON.parse(emit([a, b], [], '2026-08-31T00:00:00Z').pluginsJson) as
+      { plugins: { name: string; repo: string }[] }
+    // Both reach the artifact. A bare not.toThrow() would also pass if emit
+    // silently kept one of the two and dropped the other, which is the only
+    // way this could go wrong.
+    expect(plugins.map((p) => `${p.name}@${p.repo}`).sort()).toEqual([
+      'dsh-a@owner-a/slug',
+      'dsh-a@owner-b/slug',
+    ])
   })
 
   it('throws when an entry carries an added date later than the build date', () => {
@@ -391,6 +399,14 @@ describe('peers', () => {
   })
 })
 
+// https://shields.io/badges/endpoint-badge — the named colours the endpoint
+// schema accepts, alongside the CSS hex form. Anything else renders grey.
+const SHIELDS_COLORS = [
+  'brightgreen', 'green', 'yellow', 'yellowgreen', 'orange', 'red', 'blue',
+  'grey', 'gray', 'lightgrey', 'lightgray', 'blueviolet',
+  'success', 'important', 'critical', 'informational', 'inactive',
+]
+
 describe('the shields endpoint badge', () => {
   // GitHub's own workflow badge can say only passing / failing, and it reports
   // the last COMPLETED run — so it never says anything while a build is
@@ -412,7 +428,13 @@ describe('the shields endpoint badge', () => {
   it('carries a colour and a cache window shields will honour', () => {
     const badge = JSON.parse(emit([entry('dsh-a')], [], '2026-08-18T00:00:00.000Z').badgeJson) as
       { color: string; cacheSeconds: number }
-    expect(badge.color).toBeTruthy()
+    // shields renders a colour it does not recognise as grey rather than
+    // failing, so a truthiness check passes for 'not-a-colour' and '0.5' alike
+    // and the badge stops being blue with no test to say so. These are the
+    // names shields documents for the endpoint schema, plus its hex form.
+    const honoured =
+      SHIELDS_COLORS.includes(badge.color) || /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(badge.color)
+    expect(honoured, `shields renders "${badge.color}" grey`).toBe(true)
     // Long enough not to hammer Pages from every README view, short enough
     // that the date is never a day behind what /v1/index.json already says.
     expect(badge.cacheSeconds).toBeGreaterThanOrEqual(300)

--- a/registry/scripts/tests/fixtures/packuments.json
+++ b/registry/scripts/tests/fixtures/packuments.json
@@ -96,5 +96,19 @@
     "description": null,
     "keywords": [],
     "peers": []
+  },
+  {
+    "name": "dsh-bad-catalog",
+    "version": "1.0.0",
+    "integrity": "sha512-badcatalog",
+    "publishedAt": "2026-08-14T12:00:00.000Z",
+    "repository": "https://github.com/you/bad-catalog",
+    "license": "MIT",
+    "deprecated": false,
+    "hasBundle": true,
+    "catalog": { "category": "tool", "summary": { "en": "Renders diagrams", "zh": "渲染图表" }, "capabilities": [], "tags | extra": ["diagrams"] },
+    "description": "Declares a dsh.catalog carrying a field the schema does not know.",
+    "keywords": [],
+    "peers": []
   }
 ]

--- a/registry/scripts/tests/pipeline.test.ts
+++ b/registry/scripts/tests/pipeline.test.ts
@@ -69,12 +69,28 @@ describe('runPipeline', () => {
     expect(parsed.plugins.find(p => p.name === 'dsh-hello-plugin')?.metadata).toBe('declared')
   })
 
-  it('reports all four rejections with their codes', () => {
+  it('reports all five rejections with their codes', () => {
     const { report } = runPipeline(candidates, [], config, BUILT_AT)
     expect(report).toContain('| dsh-lib-only | no-bundle |')
     expect(report).toContain('| dsh-no-license | no-license |')
     expect(report).toContain('| dsh-fs-too1 | name-too-similar |')
     expect(report).toContain('| dsh-no-summary | no-summary |')
+    expect(report).toContain('| dsh-bad-catalog | invalid-catalog |')
+  })
+
+  it('publishes the invalid-catalog row escaped, and lists nothing for that package', () => {
+    const { report, pluginsJson } = runPipeline(candidates, [], config, BUILT_AT)
+    // The row a plugin author reads to find out why their text never appeared,
+    // produced end to end rather than at the unit gate (H-8). The
+    // author-supplied key name reaches a PUBLISHED artifact, so the `|` it
+    // carries has to be escaped or it forges a column in the table.
+    expect(report).toContain(
+      '| dsh-bad-catalog | invalid-catalog | dsh.catalog.(root): Unrecognized key: "tags \\| extra" |',
+    )
+    // "rejected, never downgraded to a derived listing" (CLAUDE.md): the
+    // package has a usable npm description, and it still must not list.
+    const parsed = JSON.parse(pluginsJson) as { plugins: { name: string }[] }
+    expect(parsed.plugins.map(p => p.name)).toEqual(['dsh-derived-plugin', 'dsh-fs-tool', 'dsh-hello-plugin'])
   })
 
   it('merges a pre-existing rejection into the emitted report', () => {

--- a/registry/scripts/tests/pipeline.test.ts
+++ b/registry/scripts/tests/pipeline.test.ts
@@ -101,15 +101,6 @@ describe('runPipeline', () => {
     expect(report).toContain('| dsh-rate-limited | fetch-failed | npm registry returned 429 fetching dsh-rate-limited |')
   })
 
-  it('produces byte-identical artifacts for the same input', () => {
-    const first = runPipeline(candidates, [], config, BUILT_AT)
-    const second = runPipeline([...candidates].reverse(), [], config, BUILT_AT)
-    expect(second.pluginsJson).toBe(first.pluginsJson)
-    expect(second.pluginsFileName).toBe(first.pluginsFileName)
-    expect(second.manifestLock).toBe(first.manifestLock)
-    expect(second.report).toBe(first.report)
-  })
-
   it('stays byte-identical when a derived listing carries a categories row', () => {
     const categorized = parseRegistryConfig({
       verified: '- name: dsh-fs-tool\n  reviewedVersion: 1.0.0\n  reviewer: github:r\n  reviewCommit: abc\n  notes: fine\n',
@@ -166,25 +157,6 @@ describe('runPipeline', () => {
     expect(firstSeen.has('dsh-lib-only')).toBe(false)
     expect(firstSeen.has('dsh-no-license')).toBe(false)
     expect(firstSeen.has('dsh-no-summary')).toBe(false)
-  })
-
-  it('produces identical data across build times', () => {
-    const first = runPipeline(candidates, [], config, BUILT_AT)
-    const second = runPipeline(candidates, [], config, '2030-01-01T00:00:00.000Z')
-    expect(second.pluginsJson).toBe(first.pluginsJson)
-    expect(second.pluginsFileName).toBe(first.pluginsFileName)
-    expect(second.manifestLock).toBe(first.manifestLock)
-    expect(second.report).toBe(first.report)
-    expect(second.indexJson).not.toBe(first.indexJson)
-  })
-
-  it('produces byte-identical artifacts with a stars pointer across runs', () => {
-    const stars = { url: 'stars.deadbeef.json', sha256: 'deadbeef' }
-    const first = runPipeline(candidates, [], config, BUILT_AT, [], stars)
-    const second = runPipeline(candidates, [], config, BUILT_AT, [], stars)
-    expect(first.indexJson).toBe(second.indexJson)
-    expect(first.pluginsJson).toBe(second.pluginsJson)
-    expect(JSON.parse(first.indexJson).stars).toEqual(stars)
   })
 
   it('keeps plugins.json bounded when a candidate carries megabyte strings', () => {
@@ -630,15 +602,23 @@ describe('determinism under every perturbation', () => {
     ].join(''),
   })
 
-  it('is byte-identical in every artifact when only the input order changes', () => {
+  it('is byte-identical in every artifact under a reversed input and a repeated run', () => {
     const first = runPipeline(candidates, repos, dated, BUILT_AT, preexisting, stars)
     const second = runPipeline(
       [...candidates].reverse(), [...repos].reverse(), dated, BUILT_AT, [...preexisting].reverse(), stars,
     )
+    // The same inputs a second time, which is a different claim from order
+    // independence: it is what would catch a Set or Map iterated in insertion
+    // order, or a clock read inside emit.
+    const repeated = runPipeline(candidates, repos, dated, BUILT_AT, preexisting, stars)
     for (const key of ['pluginsFileName', 'pluginsJson', 'indexJson', 'badgeJson', 'manifestLock', 'report'] as const) {
-      expect(second[key], key).toBe(first[key])
+      expect(second[key], `${key} moved with input order`).toBe(first[key])
+      expect(repeated[key], `${key} moved between runs`).toBe(first[key])
     }
     expect([...second.firstSeen]).toEqual([...first.firstSeen])
+    expect([...repeated.firstSeen]).toEqual([...first.firstSeen])
+    // The sidecar pointer rides the index and is not otherwise perturbed.
+    expect((JSON.parse(first.indexJson) as { stars: unknown }).stars).toEqual(stars)
   })
 
   it('keeps the hashed data identical across build times, with only the index and badge moving', () => {

--- a/registry/scripts/tests/pipeline.test.ts
+++ b/registry/scripts/tests/pipeline.test.ts
@@ -1,11 +1,16 @@
 import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { runPipeline, selectEntries, unmatchedRegistryNotes } from '../src/pipeline.ts'
 import { parseRegistryConfig } from '../src/config.ts'
 import type { Candidate, Rejection } from '../src/types.ts'
 
 const candidates = JSON.parse(
-  readFileSync('registry/scripts/tests/fixtures/packuments.json', 'utf8'),
+  // Resolved from THIS module, not the cwd: a cwd-relative fixture path makes
+  // the suite pass or fail on where it was invoked from, and running it from
+  // any other directory raised ENOENT before this.
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'packuments.json'), 'utf8'),
 ) as Candidate[]
 
 const config = parseRegistryConfig({

--- a/registry/scripts/tests/repo-guards.test.ts
+++ b/registry/scripts/tests/repo-guards.test.ts
@@ -318,3 +318,26 @@ describe('what git is allowed to pick up', () => {
     expect(tracked.trim()).toBe('packages/dsh-plugin-shop/tests/fixtures/catalog-package.tgz')
   })
 })
+
+describe('the exit criteria cannot skip silently in CI', () => {
+  it('tells the package suite that a skipped exit criterion is a failure', () => {
+    // real-install.test.ts and web-full-flow.e2e.ts are the P1 and P2 exit
+    // criteria, and both skip when no usable `dsh` is found. plugin.yml
+    // installs the harness and a browser two steps earlier for exactly that
+    // reason, so a skip there is not honest — it is a green run that proves
+    // nothing. Reproduced 2026-09-05: hiding `dsh` from PATH gave `1 skipped`
+    // and exit 0.
+    // Parsed, not windowed: the first version sliced 500 characters after the
+    // `run:` line and the comment explaining the env pushed the env itself out
+    // of the window, so a correct workflow read as broken.
+    const workflow = parse(read('.github/workflows/plugin.yml')) as {
+      jobs: Record<string, { steps: { run?: string; env?: Record<string, string> }[] }>
+    }
+    const steps = workflow.jobs.test?.steps ?? []
+    const suite = steps.find(step => (step.run ?? '').includes('packages/dsh-plugin-shop test'))
+    expect(suite, 'plugin.yml does not run the package suite').toBeDefined()
+    expect(suite?.env?.DSH_SHOP_REQUIRE_E2E, 'plugin.yml does not require the exit criteria to run')
+      .toBe('1')
+  })
+})
+

--- a/registry/scripts/tests/schema.test.ts
+++ b/registry/scripts/tests/schema.test.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { CATALOG_ERROR_MAX_LENGTH, parseCatalogSection } from '../src/schema.ts'
 import { renderJsonSchema } from '../src/emit-schema.ts'
@@ -121,7 +123,9 @@ describe('the composed error is itself a bounded published field', () => {
 
 describe('published JSON Schema', () => {
   it('matches the committed file', () => {
-    const committed = readFileSync('registry/schema/plugin-entry.schema.json', 'utf8')
+    // From the module, not the cwd — see cwd-independence.test.ts.
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+    const committed = readFileSync(join(repoRoot, 'registry', 'schema', 'plugin-entry.schema.json'), 'utf8')
     expect(committed).toBe(renderJsonSchema())
   })
 })


### PR DESCRIPTION
Plan E complete: all 13 tasks, 60 steps. Every new guard was mutation-checked — a guard that cannot fail is what this plan exists to remove, so shipping one would have been self-defeating.

## What landed

| Finding | Change |
|---|---|
| H-1 | `emit` names the plugins file by the bytes it writes |
| H-2 | *Already satisfied* — `fetchCandidates` has six cases from plan A's D-2; both of the task's mutations are caught |
| H-3 | The failure-line picker's scan order and precedence, one fixture per mutation |
| H-4 | A skipped exit criterion fails CI instead of passing quietly (`DSH_SHOP_REQUIRE_E2E`) |
| H-5 | Removed a throw that could not fire; its property now sits between the two emitted artifacts |
| H-6 | Added the repeated run; deleted three partial determinism cases |
| H-7 | Fixture paths resolve from the module, not the cwd |
| H-8 | A candidate whose declared `dsh.catalog` is invalid, harvested end to end |
| H-9a | Replaced two assertions that could not fail |
| H-9b | `repo-pins` answered lookups from `Object.prototype`; `own-version` and `normalizeRegistryUrl` covered |
| H-10 | *Closed 2026-09-04*, recorded so it is not re-investigated |
| H-11 | One temp root per host test file — 203 directories per run, 8,878 in /tmp |

## The one production fix

`readRepoPins` built its record with `{}`, so `pins['constructor']` read a function off `Object.prototype`. `constructor`, `toString` and `valueOf` are all legal npm package names and a GitHub bundle name is unrestricted, so `pins[entry.name] !== undefined` was true for a package never installed and `installed()` reported a function as its commit with `outdated: true`. Now a null-prototype record. Pure-function internals, no RPC shape, no catalog field — it rides whatever release ships next.

## Where the plan was stale, and what was done instead

Four tasks were written against a tree that has since moved, and following them verbatim would have removed coverage:

- **Task 9** — `repo-pins.test.ts` already existed from G-11, which also fixed the "finding this task surfaces and does not fix", and one of the task's fixtures would now assert the wrong thing (`RELEASE_TAG` accepts forty uppercase letters). Only the absent case was added. `normalizeRegistryUrl` was not untested either — the mutation check found the existing `npmOrigin` case by failing two tests instead of one, and the comment says so rather than claiming the gap.
- **Task 11** — plan B's C-2 union case is stronger than the block this task specified, with ties the task's fixtures did not have. Extended, not replaced.
- **Task 13** — re-measured at 101 sites and 203 leaked directories, not the 39 estimated. The guard runs under an isolated `TMPDIR` rather than counting `/tmp`, which would race with any other suite on the machine, and strips `VITEST*` from the child environment — without which the nested run exits before running anything and the guard passes for a reason unrelated to temporary directories.
- **Task 2** — nothing to do.

Each departure is annotated in `docs/plans/2026-09-03-audit-fix-e-test-gaps.md` beside the step it replaces.

## Verification

Root **760 passed (760)** / 28 files · package **633 passed (633)** / 29 files · both typechecks clean. No network, no catalog build, no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)