### PR TITLE
test(e2e): the web-flow e2e can actually run on Windows

### DIFF
--- a/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
+++ b/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
@@ -82,6 +82,7 @@ import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { chromium, type Browser, type Locator, type Page } from 'playwright'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { dshCommand, resolveDshScript } from '../../src/host/dsh-cli.ts'
 import { startInstall } from '../../src/host/executor.ts'
 
 /** Expand the 插件列表 tab's 全局插件 section, which holds the Loader entries.
@@ -120,11 +121,33 @@ import { startLocalRegistry, type LocalRegistry } from '../fixtures/local-regist
 // CI installs both (the dsh CLI in the workflow, chromium by the
 // `playwright install chromium` step); the skip fires only on machines that
 // never set them up, so the P2 exit criterion still gates the CI run.
+// The probe goes through the SAME resolution the executor uses rather than
+// `spawnSync('dsh', …)` directly — the identical correction `real-install.ts`
+// already carries, which this file was missed by. npm installs the CLI as
+// `dsh`, `dsh.cmd` and `dsh.ps1` with no `.exe`, and libuv resolves a bare
+// name against `.com`/`.exe` only, so `spawnSync('dsh', …)` is ENOENT on every
+// Windows machine. Measured 2026-09-07 on Windows 11 with a working
+// `dsh 0.1.2-rc.1`: the bare form reports `status: null, error: ENOENT` while
+// the resolved form reports `status: 0`. `hasDsh` was therefore false there
+// and the P2 exit criterion — the one test that walks the real shop UI —
+// skipped itself on the only platform whose bugs CI cannot see.
 const hasDsh = (() => {
+  const { command, args } = dshCommand({
+    dshBin: 'dsh',
+    args: ['--version'],
+    platform: process.platform,
+    execPath: process.execPath,
+    script: resolveDshScript(
+      { exists: path => existsSync(path), read: path => readFileSync(path, 'utf8') },
+      { argv1: process.argv[1], path: process.env.PATH },
+    ),
+  })
   try {
-    const probe = spawnSync('dsh', ['--version'], { stdio: 'ignore' })
-    return probe.status === 0
+    return spawnSync(command, args, { stdio: 'ignore' }).status === 0
   } catch {
+    // spawnSync throws rather than reporting when the binary cannot be started
+    // at all (a Windows .cmd shim throws EINVAL); either way the CLI is
+    // unusable from here and the case skips.
     return false
   }
 })()
@@ -232,7 +255,19 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
     // the OS pick the port; dsh prints the BOUND port in `dsh web: <url>`
     // once the Loader tree settles (the web-app bundle announces readiness),
     // so the URL is parsed from stdout rather than guessed.
-    dshProcess = spawn('dsh', ['--profile', 'web', '--no-open', '--port', '0'], {
+    // Through the same resolution as `hasDsh` above: a bare `dsh` is ENOENT on
+    // Windows, and this spawn is what boots the harness the whole flow drives.
+    const web = dshCommand({
+      dshBin: 'dsh',
+      args: ['--profile', 'web', '--no-open', '--port', '0'],
+      platform: process.platform,
+      execPath: process.execPath,
+      script: resolveDshScript(
+        { exists: path => existsSync(path), read: path => readFileSync(path, 'utf8') },
+        { argv1: process.argv[1], path: process.env.PATH },
+      ),
+    })
+    dshProcess = spawn(web.command, web.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...localRegistryEnv(), DSH_HOME: tmpHome, DSH_SHOP_CATALOG_URL: catalogServer.baseUrl },
       detached: true, // its own process group, so teardown kills the whole tree
@@ -542,9 +577,19 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await notice.waitFor({ state: 'visible', timeout: 60_000 })
       expect(await notice.textContent()).toContain('该插件的补丁包含无法热挂载的配置；重启 dsh 后生效')
       // The §8 restart offer renders for a restart-required install on a
-      // restart-capable host (this composition: spawned by vitest, no
-      // systemd markers in the env).
-      await card.locator('[data-shop-restart]').waitFor({ state: 'visible', timeout: 10_000 })
+      // restart-capable host (this composition: spawned by vitest, no systemd
+      // markers in the env) — and Windows is NOT one: `restartPlatformSupported`
+      // is `platform !== 'win32'`, because the two-phase handoff helper is a
+      // POSIX `sh` one-liner with no Windows equivalent. There the client
+      // renders the disabled notice instead, so assert the platform's actual
+      // contract rather than the POSIX one; hard-coding the offer is what made
+      // this case unpassable on Windows once the suite could run there at all.
+      if (process.platform === 'win32') {
+        await card.locator('[data-shop-restart-disabled]').waitFor({ state: 'visible', timeout: 10_000 })
+        expect(await card.locator('[data-shop-restart]').count()).toBe(0)
+      } else {
+        await card.locator('[data-shop-restart]').waitFor({ state: 'visible', timeout: 10_000 })
+      }
 
       // Nothing is live: a fresh settings mount takes a fresh inventory
       // snapshot, and the config fixture has no hot entry in it.

--- a/packages/dsh-plugin-shop/tests/fixtures/local-registry.ts
+++ b/packages/dsh-plugin-shop/tests/fixtures/local-registry.ts
@@ -22,10 +22,10 @@
 
 import { spawnSync } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 export interface LocalRegistry {
   /** Registry base, e.g. `http://127.0.0.1:<port>/` — pnpm appends the
@@ -43,13 +43,34 @@ interface PackedFixture {
   tarball: Buffer
 }
 
+/** `npm pack` as something spawnable on every platform.
+ *
+ * `spawnSync('npm', …)` is ENOENT on Windows for the same reason `spawn('dsh')`
+ * is (see `src/host/dsh-cli.ts`): npm installs as `npm`, `npm.cmd` and
+ * `npm.ps1` with no `.exe`, and libuv resolves a bare name against `.com` and
+ * `.exe` only. Running npm's own JS entry through the current node keeps the
+ * shell out of it, so a `--pack-destination` containing a space stays one
+ * argument. The bare name remains the POSIX path and the Windows fallback. */
+function npmCommand(args: readonly string[]): { command: string; args: string[] } {
+  if (process.platform === 'win32') {
+    const cli = join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')
+    if (existsSync(cli)) return { command: process.execPath, args: [cli, ...args] }
+  }
+  return { command: 'npm', args: [...args] }
+}
+
 function packFixture(root: string, dir: string): PackedFixture {
-  const result = spawnSync('npm', ['pack', '--json', '--pack-destination', root, dir], {
+  const { command, args } = npmCommand(['pack', '--json', '--pack-destination', root, dir])
+  const result = spawnSync(command, args, {
     stdio: 'pipe',
     encoding: 'utf8',
   })
   if (result.status !== 0) {
-    throw new Error(`npm pack failed for ${dir}:\n${result.stderr ?? result.stdout}`)
+    // `result.error` is the only populated field when the binary never
+    // started — the previous message read `undefined` in exactly that case,
+    // which is the one where the reason matters most.
+    const why = result.error?.message ?? result.stderr ?? result.stdout ?? '(no output)'
+    throw new Error(`npm pack failed for ${dir} (${command}):\n${why}`)
   }
   const [summary] = JSON.parse(result.stdout) as Array<{
     name: string


### PR DESCRIPTION
The P2 exit-criterion e2e — the only test that walks the real shop UI — was **silently skipping itself on Windows**, the one platform CI cannot see. Found while debugging whether `0.8.0-beta.4` has Windows defects; it does not, and this is why nobody could have known.

## The gate disabled the test that would have caught its own bug class

`hasDsh` gated on `spawnSync('dsh', ['--version'])`. npm installs the CLI as `dsh`, `dsh.cmd` and `dsh.ps1` with no `.exe`, and libuv resolves a bare name against `.com`/`.exe` only, so that call is always ENOENT there. Measured on Windows 11 against a **working** dsh 0.1.2-rc.1:

```
spawnSync('dsh', ['--version'])                 -> status: null, error: ENOENT
spawnSync(node, [<dsh>/lib/bin.js, '--version']) -> status: 0
```

`real-install.test.ts:25-29` already carries this exact correction, and its comment already names the trap — *"the one test that would have caught the defect was disabled by it."* This file was missed by it.

## Three instances of one bug class

| site | was |
|---|---|
| the `hasDsh` gate | `spawnSync('dsh', …)` |
| harness boot | `spawn('dsh', ['--profile', 'web', …])` — what the whole flow drives |
| `tests/fixtures/local-registry.ts` | `spawnSync('npm', ['pack', …])`, ENOENT for the identical reason |

All three now go through the resolution the executor itself uses. The npm one runs npm's own JS entry through the current node rather than taking a shell, so a `--pack-destination` holding a space stays one argument.

`local-registry.ts` also reported that failure as the literal string `undefined` — `result.stderr ?? result.stdout` are both null when the binary never started, and `result.error` is the only populated field, in precisely the case where the reason matters most.

## One assertion was POSIX-only rather than wrong

The §8 restart offer **cannot** render on Windows: `restartPlatformSupported()` is `platform !== 'win32'` (`index.ts:718`), because the two-phase handoff helper is a POSIX `sh` one-liner, and `restart()` refuses with that reason at `:1140`. The client renders the disabled notice instead. The case now asserts the platform's actual contract on both sides rather than hard-coding one — otherwise it can never be green on Windows.

## Result

```
Windows 11 · dsh 0.1.2-rc.1 · pnpm 11.25.0 · chromium 1234
  5 passed, 0 skipped   (24.8s)
before: 4 of 5 skipped, in 1ms
```

All five now really run on Windows: real dsh boot, real chromium, the settings modal, the shop tab, the §9.3 acknowledgement gate, a hot mount reporting no restart and appearing in the loader inventory, the config fixture's restart fallback, and the missing-peer badge.

**Linux is unchanged by construction** — `dshCommand` and `npmCommand` both return the bare name off win32, and the restart branch is guarded on `process.platform`. The non-e2e suite is identical either way (79 failing before and after on this Windows host; **0 newly failing, 0 newly passing**), typecheck clean. CI is the check for Linux.

## No product defect in beta.4

Recorded separately, since it was the question that started this: the 28 commits between `c2acc78` and `a9d433d` introduce **zero** new Windows failures (diffed by test *name*, not count: 4 new failures, all new `alsoConfirm` cases hitting the `#!/bin/sh` fixture limitation). The two suspicious failure classes were disproved against the real filesystem — the catalog cache serves 9826 entries with **0 fetches** from the real cache dir, and hot-mount patch discovery is viable for all three installed plugins including scoped names. And `shellSafeTarget`'s Windows quoting now verifies end to end: `@open-design/dsh-runtime` installs, `&path:` survives into the recorded spec, and the name reaches `dsh.profile.bundles`.

## Two of my own harness errors, recorded so they are not re-chased

- A hand-written profile `package.json` omits the `pnpm-workspace.yaml` dsh writes at init, so pnpm auto-installs the entire peer closure and drowns in registry timeouts. Let dsh initialize the profile.
- The e2e installs the shop via `file:`, so a stale `lib/` silently tests old client code. The "missing-peer badge does not render" failure was exactly that, and it disappeared on rebuild — it was never a product bug.
