### PR TITLE
test(strip-types): report the importer's status without tearing down its loop

### DIFF
--- a/registry/scripts/tests/strip-types.test.ts
+++ b/registry/scripts/tests/strip-types.test.ts
@@ -297,9 +297,26 @@ describe('importing an entry point never terminates the importing process', () =
       // the child exits 0 with an empty stdout, and every future unit test
       // that so much as imports a helper from here dies the same way, having
       // reported success.
+      //
+      // `process.exitCode`, never `process.exit()`: the status has to survive
+      // the child's own teardown, and on Windows it does not. `process.exit()`
+      // tears the loop down with libuv work still in flight, which aborts
+      // inside `uv_async_send` — `Assertion failed: !(handle->flags &
+      // UV_HANDLE_CLOSING), file src\win\async.c, line 94` — and replaces the
+      // status with 0xC0000409, Windows' fast-fail code. The mark still
+      // reached stdout, so the property asserted below held and only the
+      // child's way of REPORTING it broke. Measured on windows-latest, node
+      // v24.19.0: `emit-schema.ts` failed four runs of four at `2fbdb3b`
+      // while its parent commit passed twice on the same runner image and
+      // node build. It is the one that fails because its import graph is the
+      // lightest of the five, so it reaches the exit soonest and leaves that
+      // work the least time to drain — the other four are not safe, only
+      // slower. Assigning the status and returning lets the loop finish; a
+      // module-scope `process.exit(0)` still pre-empts the assignment, so the
+      // regression described above stays caught.
       const importer = `await import(${importSpecifier(file)})\n`
         + `process.stdout.write(${JSON.stringify(IMPORTER_MARK)})\n`
-        + `process.exit(${String(IMPORTER_STATUS)})\n`
+        + `process.exitCode = ${String(IMPORTER_STATUS)}\n`
       const result = spawnSync(
         process.execPath,
         ['--experimental-strip-types', '--input-type=module', '-e', importer],


### PR DESCRIPTION
`windows` has been red on `main` since #29 merged. One case fails:
`strip-types.test.ts` → `leaves the importer alive and in control after
importing emit-schema.ts`.

## The product is not what broke

```
stdout: "importer survived"
stderr: Assertion failed: !(handle->flags & UV_HANDLE_CLOSING),
        file src\win\async.c, line 94
exit 3221226505 = 0xC0000409 = STATUS_STACK_BUFFER_OVERRUN (__fastfail)
```

The mark reached stdout, so the first assertion passed and the property the
test exists to assert — importing an entry point does not terminate the
importer — **held**. What broke is how the child reports it.

The importer ended in `process.exit(43)`. On Windows that tears the loop down
with libuv work still in flight; the abort in `uv_async_send` replaces the
status with Windows' fast-fail code.

## Measurement

All on `windows-latest` image `20260824.214.3`, node `v24.19.0`:

| tree | runs | result |
|---|---|---|
| `623fc79` — parent of #29 | attempt 2, attempt 3 | **success 2/2** |
| `2fbdb3b` — #29 merge | 1 | failure |
| `b834f82` | 3 | failure |

Four failures, byte-identical signature every time; two passes on the parent,
on the same image and node build. The environment is not what changed.

#29 touched neither `emit-schema.ts` nor `schema.ts`, but it added 109 lines to
`types.ts`, which is in that entry point's import chain
(`emit-schema.ts → schema.ts → types.ts`) — a timing change, not a logic one.
`emit-schema.ts` is the one that fails because its import graph is the lightest
of the five: it reaches the exit soonest and leaves that work the least time to
drain. **The other four are not safe, only slower.**

## The change

```diff
-  + `process.exit(${String(IMPORTER_STATUS)})\n`
+  + `process.exitCode = ${String(IMPORTER_STATUS)}\n`
```

Assigning the status and returning lets the loop finish on its own.

The regression this test exists to catch still fails it: a module-scope
`process.exit(0)` pre-empts the assignment, so the child exits 0 with nothing
on stdout — both assertions still fire. Verified by hand on Linux: the new form
exits 43 carrying the mark, the pre-empted one exits 0 carrying nothing.

## Verification

- 939 tests pass, `tsc --noEmit` clean — on Linux, which establishes only that
  nothing else moved.
- **Windows CI on this PR is the oracle for the fix itself.**

## Noted, not changed

`publish-catalog.ts` calls `process.exit(0)`/`(1)` on its own success and
failure paths, which is the same shape. It runs only on `ubuntu-latest`, so it
is not a live risk today, and widening this PR to cover it would put an
unverifiable product change next to a test change Windows CI can actually
prove. Recorded here rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
