### PR TITLE
test(windows): a fake dsh node can spawn, so the last four files run there too

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,8 +9,10 @@ name: windows
 # there. Between them they hid 24 results, some red and some passing while
 # proving nothing.
 #
-# So this leg exists to make that class fail somewhere. It is deliberately
-# narrow — see the job comment for what it does NOT cover and why.
+# So this leg exists to make that class fail somewhere. It started deliberately
+# narrow, excluding four files whose fakes Windows could not spawn; it now runs
+# both suites whole — see the job comment for the three cases that still skip
+# themselves and why each is a product boundary rather than a gap.
 
 on:
   push:
@@ -44,38 +46,34 @@ jobs:
       # The root suite (registry/scripts/tests/**) in full. Measured green on
       # Windows, and it is where the `import()` specifier bug lived.
       - run: pnpm test
-      # The package's own `test` script is `tsdown && tsdown -c
-      # tsdown.client.config.ts && vitest run`, so it BUILDS first, and two
-      # cases depend on that: `apply.client.spec.tsx` imports
-      # `dsh-plugin-shop/remote`, a self-referential export resolving into
-      # `lib/`, and `own-version.test.ts` asserts `lib/index.js` exists. The
-      # step below cannot use the script — the exclusions have to reach vitest,
-      # and `pnpm test -- --exclude …` does not deliver them (measured: the
-      # full 30 files ran) — so the two builds are spelled out here instead.
+      # The package suite, whole, through the package's OWN `test` script —
+      # `tsdown && tsdown -c tsdown.client.config.ts && vitest run`. The two
+      # builds are load-bearing, not incidental: `apply.client.spec.tsx`
+      # imports `dsh-plugin-shop/remote`, a self-referential export resolving
+      # into `lib/`, and `own-version.test.ts` asserts `lib/index.js` exists.
       # Their absence is what made this leg's first run red while it was green
       # on a working tree that already had a `lib/`.
-      - run: pnpm -C packages/dsh-plugin-shop exec tsdown
-      - run: pnpm -C packages/dsh-plugin-shop exec tsdown -c tsdown.client.config.ts
-      # The package suite MINUS four files. They fake the `dsh` CLI with a
-      # `#!/bin/sh` script and spawn it by bare name, or assert on a symlink,
-      # so 55 of their cases fail on Windows for one shared reason that has
-      # nothing to do with what this leg is guarding. Measured, not guessed:
-      # executor 34, index 18, restart 2, profile 1.
       #
-      # An exclusion list rather than an allowlist, deliberately: a NEW test
-      # file is covered by default, so the next Windows regression fails here
-      # instead of being quietly outside the net. Removing an entry is the
-      # work of teaching those fakes to write a `.cmd` shim (or to spawn a
-      # node script) the way `src/host/dsh-cli.ts` already resolves one.
+      # This step used to spell the builds out and call vitest itself, because
+      # it had to reach vitest with four `--exclude` flags that `pnpm test --`
+      # would not deliver. It excluded executor, index, restart and profile,
+      # whose fakes were `#!/bin/sh` scripts spawned by bare name — which
+      # Windows cannot start at all: 55 cases failing for one reason that had
+      # nothing to do with what this leg guards. The fakes are node scripts
+      # now (`tests/fixtures/fake-dsh.ts`), so there is nothing left to
+      # exclude, no file outside the net, and no reason to diverge from what a
+      # developer runs.
+      #
+      # Four cases inside those files still skip themselves on Windows, and
+      # each names the product boundary it is standing at rather than a
+      # fixture that could be fixed: the POSIX-only restart handoff (three —
+      # two in restart, one in index) and the POSIX spelling of the
+      # missing-CLI advice (one, in executor). The Windows arms of both are
+      # asserted elsewhere in the same files. Measured on Windows 11 at this
+      # commit: 777 passed, 4 skipped, 0 failed across all 30 files.
       #
       # `tests/client/web-full-flow.e2e.ts` is in scope but self-skips:
       # `describe.skipIf(!hasDsh || !hasChromium)`, and this leg deliberately
       # installs neither, nor does it set DSH_SHOP_REQUIRE_E2E. plugin.yml is
       # where that criterion runs, against a pinned harness.
-      - run: >
-          pnpm -C packages/dsh-plugin-shop exec vitest run
-          --exclude tests/host/executor.test.ts
-          --exclude tests/host/index.test.ts
-          --exclude tests/host/restart.test.ts
-          --exclude tests/host/profile.test.ts
-          --exclude '**/node_modules/**'
+      - run: pnpm -C packages/dsh-plugin-shop test

--- a/packages/dsh-plugin-shop/src/host/dsh-cli.ts
+++ b/packages/dsh-plugin-shop/src/host/dsh-cli.ts
@@ -31,6 +31,27 @@ export const DSH_PACKAGE = '@deepseek-ai/dsh'
  * also the unscoped name its plain-string `bin` form would take. */
 const DSH_BIN_NAME = 'dsh'
 
+/**
+ * A `dshBin` that names a JavaScript entry rather than a program.
+ *
+ * Such a file cannot be spawned anywhere: Windows needs a PE image, and POSIX
+ * needs a shebang plus the exec bit that an entry shipped inside a package
+ * does not reliably carry. The npm-installed CLI's real entry IS one of these
+ * — `bin: { dsh: 'lib/bin.js' }` — so a caller pinning a specific dsh
+ * installation has no other file to name, and {@link resolveDshScript} hands
+ * back exactly this shape for the branch below to run through node.
+ *
+ * Platform-independent on purpose. The `dsh` branch is a Windows workaround
+ * for PATH lookup; this is not a workaround at all but the only correct way
+ * to start a JS entry, and gating it on Windows would leave a POSIX caller
+ * with an ENOEXEC naming a file that is perfectly valid.
+ *
+ * The one thing it gives up is a `.js` entry whose shebang names some other
+ * interpreter. `dshBin` names the dsh CLI, which is a node program, so the
+ * trade is one hypothetical against a shape the CLI actually ships.
+ */
+const JS_ENTRY = /\.[cm]?js$/
+
 export interface DshCliFs {
   exists: (path: string) => boolean
   read: (path: string) => string
@@ -45,10 +66,13 @@ export interface DshCommand {
 /**
  * The command that starts the dsh CLI with `args`.
  *
- * The node route replaces exactly one thing: looking the bare name `dsh` up
- * on PATH, which on Windows can never succeed. A `dshBin` naming a specific
- * file is the caller's explicit choice and is spawned as given — honoring it
- * and reporting the real failure beats silently running something else.
+ * For the bare name the node route replaces exactly one thing: looking `dsh`
+ * up on PATH, which on Windows can never succeed. A `dshBin` naming a
+ * specific file is the caller's explicit choice and is spawned as given —
+ * honoring it and reporting the real failure beats silently running something
+ * else — with one exception, {@link JS_ENTRY}, where "as given" is not a
+ * runnable command on any platform and node is what the caller must have
+ * meant.
  */
 export function dshCommand(options: {
   dshBin: string
@@ -58,9 +82,11 @@ export function dshCommand(options: {
   script: string | null
 }): DshCommand {
   const { dshBin, args, platform, execPath, script } = options
-  if (platform === 'win32' && script !== null && dshBin === DSH_BIN_NAME) {
-    return { command: execPath, args: [script, ...args] }
+  if (dshBin === DSH_BIN_NAME) {
+    if (platform === 'win32' && script !== null) return { command: execPath, args: [script, ...args] }
+    return { command: dshBin, args: [...args] }
   }
+  if (JS_ENTRY.test(dshBin)) return { command: execPath, args: [dshBin, ...args] }
   return { command: dshBin, args: [...args] }
 }
 

--- a/packages/dsh-plugin-shop/tests/fixtures/fake-dsh.ts
+++ b/packages/dsh-plugin-shop/tests/fixtures/fake-dsh.ts
@@ -1,0 +1,74 @@
+/**
+ * A fake `dsh` CLI that runs on every platform.
+ *
+ * The fixtures this replaces were `#!/bin/sh` scripts written with
+ * `chmod 0o755`, and on Windows there is no form of `spawn()` that can start
+ * one: the file carries no PE image, so `CreateProcess` refuses it, and node
+ * has refused `.cmd`/`.bat` without a shell since the 2024 batfile
+ * argument-injection fix — so wrapping `sh` in a `.cmd` shim is not an escape
+ * either. That is why `executor.test.ts`, `index.test.ts` and
+ * `restart.test.ts` contributed 54 of the 55 Windows failures and had to be
+ * excluded from the windows CI leg by name.
+ *
+ * A node script has no such problem: `dshCommand` runs a `dshBin` naming a JS
+ * entry through the node already running the test (`JS_ENTRY` in
+ * `src/host/dsh-cli.ts`), which is the same route production takes to the
+ * real CLI on Windows. No shell is involved on either platform, so an
+ * argument carrying a space or an `&` stays one argument.
+ *
+ * The body is written as source text rather than passed as a function,
+ * because it runs in a CHILD process and cannot close over the test's scope.
+ * Everything it needs arrives through interpolation or through `argv`.
+ */
+
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Write `dir/dsh.mjs` and return its path, ready to hand to `dshBin`.
+ *
+ * `body` is ESM source with three bindings already in scope:
+ *
+ *  - `argv` — the CLI's own arguments, `['plugin', '--profile', 'web', 'add',
+ *    '<spec>']`. `argv[0]` is what a shell fixture called `$1`, so the line
+ *    those fixtures logged is `argv.slice(0, 5).join(' ')`.
+ *  - `fs` — `node:fs`, so a body that records something needs no import.
+ *  - `out` — one line to stdout. `process.stdout.write` remains available for
+ *    the cases that deliberately emit no trailing newline, and the contrast
+ *    between the two spellings is the point: an unterminated line is an
+ *    assertion in `lineSink`'s tests, not an oversight.
+ *
+ * Exiting is the body's job, as it was the script's: `process.exit(n)`.
+ *
+ * The `.mjs` extension is load-bearing twice over — it is what `JS_ENTRY`
+ * matches, and it is what makes the file ESM whatever the nearest
+ * `package.json` says, which for a fixture under the OS temp directory is
+ * whatever happens to be lying around above it.
+ */
+export function fakeDsh(dir: string, body: string, name = 'dsh.mjs'): string {
+  const bin = join(dir, name)
+  writeFileSync(bin, [
+    "import * as fs from 'node:fs'",
+    'const argv = process.argv.slice(2)',
+    "const out = line => process.stdout.write(line + '\\n')",
+    body,
+    '',
+  ].join('\n'))
+  return bin
+}
+
+/**
+ * The commonest fixture: append the argv line to `calls.log` beside the
+ * script, print one progress line, and exit with `exitCode`.
+ *
+ * Appending rather than truncating, because several cases spawn one fixture
+ * more than once and read the log back as a sequence — which is what the
+ * shell version's `>>` gave them.
+ */
+export function fakeDshRecording(dir: string, exitCode: number, options: { silent?: boolean } = {}): string {
+  return fakeDsh(dir, [
+    `fs.appendFileSync(${JSON.stringify(join(dir, 'calls.log'))}, argv.slice(0, 5).join(' ') + '\\n')`,
+    ...(options.silent === true ? [] : ["out('installing...')"]),
+    `process.exit(${exitCode})`,
+  ].join('\n'))
+}

--- a/packages/dsh-plugin-shop/tests/host/dsh-cli.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/dsh-cli.test.ts
@@ -61,9 +61,38 @@ describe('dshCommand', () => {
   it('spawns an explicitly named binary as given, rather than substituting the entry', () => {
     // The node route replaces PATH lookup of the bare name, nothing else. A
     // caller that named a file meant that file; the real-installation test
-    // and the fixture tests both depend on being spawned as written.
+    // depends on being spawned as written.
     expect(dshCommand({ dshBin: 'C:\\custom\\dsh.cmd', args, platform: 'win32', execPath: 'C:\\node\\node.exe', script: 'C:\\npm\\dsh\\lib\\bin.js' }))
       .toEqual({ command: 'C:\\custom\\dsh.cmd', args: [...args] })
+  })
+
+  it('runs an explicitly named JS entry through node, on every platform', () => {
+    // The one exception to the rule above, and not a Windows workaround: a
+    // `.js` file is not a runnable command anywhere. Windows refuses it for
+    // want of a PE image; POSIX needs a shebang and an exec bit that an entry
+    // shipped inside a package does not reliably carry. The CLI's own entry
+    // IS this shape — `bin: { dsh: 'lib/bin.js' }` — so it is what a caller
+    // pinning one installation has to name.
+    //
+    // `execPath` is asserted rather than the entry: substituting `script`
+    // here would silently run a DIFFERENT dsh than the one named, which is
+    // the failure the case above exists to prevent.
+    for (const platform of ['win32', 'linux', 'darwin'] as const) {
+      for (const bin of ['/opt/dsh/lib/bin.js', '/opt/dsh/lib/bin.mjs', '/opt/dsh/lib/bin.cjs']) {
+        expect(dshCommand({ dshBin: bin, args, platform, execPath: '/usr/bin/node', script: '/elsewhere/bin.js' }))
+          .toEqual({ command: '/usr/bin/node', args: [bin, ...args] })
+      }
+    }
+  })
+
+  it('leaves a program whose name merely contains js alone', () => {
+    // The rule is an EXTENSION, not a substring: `dsh-js` and `js` are
+    // ordinary executables, and running one through node would spawn node
+    // against a binary file.
+    for (const bin of ['/usr/local/bin/dsh-js', '/usr/local/bin/js', '/usr/local/bin/dsh.jsx']) {
+      expect(dshCommand({ dshBin: bin, args, platform: 'linux', execPath: '/usr/bin/node', script: null }))
+        .toEqual({ command: bin, args: [...args] })
+    }
   })
 
   it('does not alias the caller\'s args array', () => {

--- a/packages/dsh-plugin-shop/tests/host/executor.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/executor.test.ts
@@ -1,28 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, writeFileSync, chmodSync, readFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { activationFailureDetail, shellSafeTarget, installFailureDetail, installTimeoutDetail, killTree, lineSink, spawnFailureDetail, startInstall, startUninstall, type InstallStatus } from '../../src/host/executor.ts'
 import type { HotRestartReason } from '../../src/host/hot.ts'
+import { fakeDsh, fakeDshRecording } from '../fixtures/fake-dsh.ts'
 import { fileTempRoot } from './temp-root.ts'
 
 const TEMP_ROOT = fileTempRoot('executor')
 
 // A fixture `dsh` that records its full argv in a marker file and exits with
 // the requested code, proving the executor passes --profile and the pinned
-// spec through: `dsh plugin --profile <p> add <spec>` is `$1 $2 $3 $4 $5`.
+// spec through: `dsh plugin --profile <p> add <spec>` is `argv.slice(0, 5)`.
 function fixtureDsh(exitCode: number): string {
-  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-'))
-  const bin = join(dir, 'dsh')
-  writeFileSync(bin, [
-    '#!/bin/sh',
-    `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`,
-    'echo "installing..."',
-    `exit ${exitCode}`,
-    '',
-  ].join('\n'))
-  chmodSync(bin, 0o755)
-  return bin
+  return fakeDshRecording(mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-')), exitCode)
 }
 
 // A fixture `dsh` that emits CRLF line endings, as every Windows console
@@ -30,17 +21,11 @@ function fixtureDsh(exitCode: number): string {
 // bytes come from the script, not the host, so this reproduces the Windows
 // stream shape while running on Linux or macOS.
 function fixtureDshCrlf(exitCode: number, lines: readonly string[]): string {
-  const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-crlf-'))
-  const bin = join(dir, 'dsh')
-  const payload = lines.map(line => `${line}\\r\\n`).join('')
-  writeFileSync(bin, [
-    '#!/bin/sh',
-    `printf '%b' '${payload}'`,
-    `exit ${exitCode}`,
-    '',
+  const payload = lines.map(line => `${line}\r\n`).join('')
+  return fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-crlf-')), [
+    `process.stdout.write(${JSON.stringify(payload)})`,
+    `process.exit(${exitCode})`,
   ].join('\n'))
-  chmodSync(bin, 0o755)
-  return bin
 }
 
 describe('startInstall', () => {
@@ -63,11 +48,13 @@ describe('startInstall', () => {
     expect(status.detail).toContain('dsh plugin --profile web install')
   })
 
-  // POSIX-only: the detail is platform-dependent by design, and on Windows a
-  // missing binary reports the entry-lookup failure instead (see
-  // `spawnFailureDetail`). Every other case in this file already depends on
-  // `#!/bin/sh` fixtures, so the file as a whole does not run on Windows; the
-  // Windows path is covered by dsh-cli.test.ts and real-install.test.ts.
+  // POSIX-only, and now the ONLY case in this file that is: the detail is
+  // platform-dependent by design, and on Windows a missing binary reports the
+  // entry-lookup failure instead (see `spawnFailureDetail`). The rest of the
+  // file used to be skipped WITH it, because every fixture was a `#!/bin/sh`
+  // script; they are node scripts now and run everywhere. The Windows arm of
+  // this particular message is asserted directly in `spawnFailureDetail`'s
+  // own cases below, which take the platform as an argument.
   it.skipIf(process.platform === 'win32')('reports failed with the CLI hint when dsh is not on PATH', async () => {
     const install = startInstall({ profile: 'web', spec: 'dsh-hello-plugin@1.2.0', dshBin: join(tmpdir(), 'no-such-dsh-bin') })
     const status = await install.finished
@@ -87,16 +74,14 @@ describe('startInstall', () => {
 
   it('serializes installs into one profile', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-serialize-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      `echo "start $3" >> "${join(dir, 'events.log')}"`,
-      'sleep 0.2',
-      `echo "end $3" >> "${join(dir, 'events.log')}"`,
-      'exit 0',
-      '',
+    const eventsLog = JSON.stringify(join(dir, 'events.log'))
+    const bin = fakeDsh(dir, [
+      // `argv[2]` is the profile: what the shell fixture spelled `$3`.
+      `fs.appendFileSync(${eventsLog}, 'start ' + argv[2] + '\\n')`,
+      'await new Promise(resolve => setTimeout(resolve, 200))',
+      `fs.appendFileSync(${eventsLog}, 'end ' + argv[2] + '\\n')`,
+      'process.exit(0)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     const first = startInstall({ profile: 'web', spec: 'a@1.0.0', dshBin: bin })
     const second = startInstall({ profile: 'web', spec: 'b@1.0.0', dshBin: bin })
     const other = startInstall({ profile: 'tui', spec: 'c@1.0.0', dshBin: bin })
@@ -113,19 +98,10 @@ describe('startInstall', () => {
   })
 
   it('caps the log at 200 lines, dropping the oldest', async () => {
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-cap-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      'i=1',
-      'while [ $i -le 250 ]; do',
-      '  echo "line $i"',
-      '  i=$((i+1))',
-      'done',
-      'exit 0',
-      '',
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-cap-')), [
+      'for (let i = 1; i <= 250; i += 1) out(`line ${i}`)',
+      'process.exit(0)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     const install = startInstall({ profile: 'web', spec: 'a@1.0.0', dshBin: bin })
     const status = await install.finished
     // 250 newline-terminated lines: the cap keeps exactly the newest 200,
@@ -135,16 +111,10 @@ describe('startInstall', () => {
   })
 
   it('surfaces stderr verbatim in the log with the recovery hint on failure', async () => {
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-stderr-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      'echo "boom one" >&2',
-      'echo "boom two" >&2',
-      'exit 1',
-      '',
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-stderr-')), [
+      "process.stderr.write('boom one\\nboom two\\n')",
+      'process.exit(1)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     const install = startInstall({ profile: 'web', spec: 'a@1.0.0', dshBin: bin })
     const status = await install.finished
     expect(status.state).toBe('failed')
@@ -279,22 +249,15 @@ describe('startInstall post-install confirm (§7.2 step 6)', () => {
   // pre-seeded. An exit-0 stub that writes nothing can only ever model "the
   // install added nothing".
   function fixtureDshAdding(home: string, name: string, spec: string): string {
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-add-'))
-    const bin = join(dir, 'dsh')
-    const manifest = join(home, 'profiles', 'web', 'package.json')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      'echo "installing..."',
-      `node -e '`
-      + `const f=process.argv[1];const fs=require("fs");const m=JSON.parse(fs.readFileSync(f,"utf8"));`
-      + `m.dependencies=m.dependencies||{};m.dependencies[process.argv[2]]=process.argv[3];`
-      + `fs.writeFileSync(f,JSON.stringify(m));`
-      + `' "${manifest}" "${name}" "${spec}"`,
-      'exit 0',
-      '',
+    const manifest = JSON.stringify(join(home, 'profiles', 'web', 'package.json'))
+    return fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-add-')), [
+      "out('installing...')",
+      `const manifest = JSON.parse(fs.readFileSync(${manifest}, 'utf8'))`,
+      'manifest.dependencies = manifest.dependencies || {}',
+      `manifest.dependencies[${JSON.stringify(name)}] = ${JSON.stringify(spec)}`,
+      `fs.writeFileSync(${manifest}, JSON.stringify(manifest))`,
+      'process.exit(0)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
-    return bin
   }
 
   it('refuses a leftover bundle row when this install added something else', async () => {
@@ -419,17 +382,13 @@ describe('startInstall post-install confirm (§7.2 step 6)', () => {
     // AFTER read succeeds and only the prior state is missing.
     writeFileSync(manifestPath, '{ not json')
     const after = { 'dsh-hello-plugin': '1.0.0', 'dsh-memory': '2.1.0' }
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-replace-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      'echo "installing..."',
-      `printf '%s' '${JSON.stringify({ dependencies: after, dsh: { profile: { bundles: [] } } })}'`
-      + ` > "${manifestPath}"`,
-      'exit 0',
-      '',
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-replace-')), [
+      "out('installing...')",
+      `fs.writeFileSync(${JSON.stringify(manifestPath)}, ${JSON.stringify(
+        JSON.stringify({ dependencies: after, dsh: { profile: { bundles: [] } } }),
+      )})`,
+      'process.exit(0)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     const status = await startInstall({
       profile: 'web',
       spec: '@acme/plugin@1.0.0',
@@ -451,18 +410,13 @@ describe('startInstall post-install confirm (§7.2 step 6)', () => {
     const profileDir = join(home, 'profiles', 'web')
     mkdirSync(profileDir, { recursive: true })
     const manifestPath = join(profileDir, 'package.json')
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-fresh-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      `printf '%s' '${JSON.stringify({
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-fixture-fresh-')), [
+      `fs.writeFileSync(${JSON.stringify(manifestPath)}, ${JSON.stringify(JSON.stringify({
         dependencies: { 'some-monorepo-root': 'github:acme/mono#0123456789abcdef' },
         dsh: { profile: { bundles: [] } },
-      })}' > "${manifestPath}"`,
-      'exit 0',
-      '',
+      }))})`,
+      'process.exit(0)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     const status = await startInstall({
       profile: 'web',
       spec: '@acme/plugin@1.0.0',
@@ -487,9 +441,11 @@ describe('startInstall post-install confirm (§7.2 step 6)', () => {
 describe('startInstall quotes a subpackage spec for the shell dsh uses on Windows', () => {
   function specSeenByDsh(platform: NodeJS.Platform, spec: string): Promise<string> {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-argv-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, ['#!/bin/sh', `printf '%s' "$5" > "${join(dir, 'spec.txt')}"`, 'exit 0', ''].join('\n'))
-    chmodSync(bin, 0o755)
+    // `argv[4]` is the spec: what the shell fixture spelled `$5`.
+    const bin = fakeDsh(dir, [
+      `fs.writeFileSync(${JSON.stringify(join(dir, 'spec.txt'))}, argv[4])`,
+      'process.exit(0)',
+    ].join('\n'))
     return startInstall({ profile: 'web', spec, dshBin: bin, platform }).finished
       .then(() => readFileSync(join(dir, 'spec.txt'), 'utf8'))
   }
@@ -954,19 +910,22 @@ describe('installFailureDetail', () => {
 })
 
 describe('the install deadline and the process group (F-1)', () => {
+  // The grandchild INHERITS stdout, which is the whole point: it holds the
+  // pipe open after its parent has exited, and the executor must settle on
+  // the exit rather than waiting for a stream nobody will close. `sleep &`
+  // did this in the shell version; a detached node timer does it here.
   function grandchildDsh(sleepSeconds: number): { bin: string; pidFile: string } {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-grandchild-'))
     const pidFile = join(dir, 'grandchild.pid')
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      'echo "installing..."',
-      `sleep ${sleepSeconds} &`,
-      `echo $! > "${pidFile}"`,
-      'exit 0',
-      '',
+    const bin = fakeDsh(dir, [
+      "const { spawn } = await import('node:child_process')",
+      "out('installing...')",
+      `const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, ${sleepSeconds * 1000})'],`
+      + " { stdio: ['ignore', 'inherit', 'inherit'], detached: true })",
+      'child.unref()',
+      `fs.writeFileSync(${JSON.stringify(pidFile)}, String(child.pid))`,
+      'process.exit(0)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     return { bin, pidFile }
   }
 
@@ -987,15 +946,18 @@ describe('the install deadline and the process group (F-1)', () => {
 
   it('stops a command that outlives its deadline and frees the profile queue', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-deadline-'))
-    const hung = join(dir, 'dsh')
-    writeFileSync(hung, [
-      '#!/bin/sh',
-      'sleep 30 &',
-      `echo $! > "${join(dir, 'gpid')}"`,
-      'wait',
-      '',
+    // NOT detached, unlike the case above: this grandchild has to be inside
+    // whatever the deadline tears down — the process group on POSIX, the
+    // `taskkill /T` tree on Windows — because that is what the last
+    // assertion checks. Its parent then waits forever, so the only way out
+    // is the deadline.
+    const hung = fakeDsh(dir, [
+      "const { spawn } = await import('node:child_process')",
+      "const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'],"
+      + " { stdio: ['ignore', 'inherit', 'inherit'] })",
+      `fs.writeFileSync(${JSON.stringify(join(dir, 'gpid'))}, String(child.pid))`,
+      'await new Promise(() => {})',
     ].join('\n'))
-    chmodSync(hung, 0o755)
 
     const first = startInstall({ profile: 'deadline', spec: 'a@1.0.0', dshBin: hung, timeoutMs: 300 })
     const second = startInstall({ profile: 'deadline', spec: 'b@1.0.0', dshBin: fixtureDsh(0) })
@@ -1082,17 +1044,12 @@ describe('lineSink (F-6)', () => {
 
 describe('startInstall line assembly (F-6)', () => {
   it('reports the whole line when the stream splits it, not the fragment', async () => {
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-split-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      "printf '%s' ' ERR_PNPM_FE'",
-      'sleep 0.3',
-      "printf '%s\\n' 'TCH_404 GET https://r/x: Not Found - 404'",
-      'exit 1',
-      '',
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-split-')), [
+      "process.stdout.write(' ERR_PNPM_FE')",
+      'await new Promise(resolve => setTimeout(resolve, 300))',
+      "process.stdout.write('TCH_404 GET https://r/x: Not Found - 404\\n')",
+      'process.exit(1)',
     ].join('\n'))
-    chmodSync(bin, 0o755)
     const status = await startInstall({ profile: 'split', spec: 'a@1.0.0', dshBin: bin }).finished
     expect(status.state).toBe('failed')
     expect(status.log).toEqual([' ERR_PNPM_FETCH_404 GET https://r/x: Not Found - 404'])
@@ -1100,10 +1057,10 @@ describe('startInstall line assembly (F-6)', () => {
   })
 
   it('keeps a final unterminated line in the log', async () => {
-    const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-unterminated-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, ['#!/bin/sh', "printf '%s' 'the bundle did not appear'", 'exit 1', ''].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'dsh-unterminated-')), [
+      "process.stdout.write('the bundle did not appear')",
+      'process.exit(1)',
+    ].join('\n'))
     const status = await startInstall({ profile: 'unterminated', spec: 'a@1.0.0', dshBin: bin }).finished
     expect(status.log).toEqual(['the bundle did not appear'])
     expect(status.detail).toMatch(/did not appear/)
@@ -1167,11 +1124,17 @@ describe('spawnFailureDetail', () => {
 })
 
 describe('the child environment (F-12 residual)', () => {
+  /** Records what the child saw in `SHOP_F12_PROBE`, absent as the empty
+   * string — which is what `"$SHOP_F12_PROBE"` expanded to in the shell
+   * fixture, so both cases keep their original assertions. */
+  const envProbeDsh = (dir: string): string => fakeDsh(dir, [
+    `fs.writeFileSync(${JSON.stringify(join(dir, 'env.txt'))}, (process.env.SHOP_F12_PROBE ?? '') + '\\n')`,
+    'process.exit(0)',
+  ].join('\n'))
+
   it('passes the parent environment to the child, deliberately', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-env-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, ['#!/bin/sh', `printf '%s\n' "$SHOP_F12_PROBE" > "${join(dir, 'env.txt')}"`, 'exit 0', ''].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = envProbeDsh(dir)
     process.env.SHOP_F12_PROBE = 'inherited'
     try {
       await startInstall({ profile: 'env', spec: 'a@1.0.0', dshBin: bin }).finished
@@ -1183,9 +1146,7 @@ describe('the child environment (F-12 residual)', () => {
 
   it('uses only the given environment when one is passed', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-env-pinned-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, ['#!/bin/sh', `printf '%s\n' "$SHOP_F12_PROBE" > "${join(dir, 'env.txt')}"`, 'exit 0', ''].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = envProbeDsh(dir)
     process.env.SHOP_F12_PROBE = 'inherited'
     try {
       await startInstall({ profile: 'env-pinned', spec: 'a@1.0.0', dshBin: bin, env: { PATH: process.env.PATH ?? '' } }).finished

--- a/packages/dsh-plugin-shop/tests/host/index.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createHash } from 'node:crypto'
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import ShopGateway, { verifyTarballSha256 } from '../../src/host/index.ts'
@@ -8,6 +8,7 @@ import type { InventoryEntry, LoaderEntryLike, ShopGatewayOptions, ShopInstallSt
 import type { HotMountResult } from '../../src/host/hot.ts'
 import type { CatalogResult, CatalogSnapshot, LoadCatalogOptions } from '../../src/host/catalog.ts'
 import type { CatalogEntry } from '../../src/host/types.ts'
+import { fakeDsh, fakeDshRecording } from '../fixtures/fake-dsh.ts'
 import { fileTempRoot } from './temp-root.ts'
 
 const TEMP_ROOT = fileTempRoot('index')
@@ -50,9 +51,7 @@ describe('two catalog entries share one name (G-1)', () => {
   const bob: CatalogEntry = { ...alice, version: bobCommit, integrity: bobCommit, repo: 'bob/dsh-foo' }
 
   function gatewayWithBoth(dir: string, dependencies: Record<string, string>): ShopGateway {
-    const bin = join(dir, 'fake-dsh')
-    writeFileSync(bin, ['#!/bin/sh', `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`, 'exit 0', ''].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = fakeDshRecording(dir, 0, { silent: true })
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-dup-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies }))
     return new ShopGateway(stubCtx(), {
@@ -381,14 +380,7 @@ describe('ShopGateway.catalog', () => {
 // a rejection's no-spawn property be proven by the file's absence.
 function gatewayWithSnapshot(snapshot: CatalogSnapshot, options: Partial<ShopGatewayOptions> = {}): { gateway: ShopGateway; callsLog: string } {
   const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-fixture-'))
-  const bin = join(dir, 'dsh')
-  writeFileSync(bin, [
-    '#!/bin/sh',
-    `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`,
-    'exit 0',
-    '',
-  ].join('\n'))
-  chmodSync(bin, 0o755)
+  const bin = fakeDshRecording(dir, 0, { silent: true })
   // The install flow reads the running profile manifest before spawning (to
   // tell an update from a fresh install); the fixture supplies one.
   const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-profile-'))
@@ -864,9 +856,7 @@ describe('ShopGateway.restart', () => {
   // ever spawned by a test.
   function restartingGateway(options: { exit: ReturnType<typeof vi.fn>; cacheDir?: string; restartArgv?: string[] }): ShopGateway {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-gateway-restart-'))
-    const bin = join(dir, 'dsh')
-    writeFileSync(bin, `#!/bin/sh\necho "$1 $2 $3" >> "${join(dir, 'calls.log')}"\nexit 0\n`)
-    chmodSync(bin, 0o755)
+    const bin = fakeDshRecording(dir, 0, { silent: true })
     return new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/',
       cacheDir: options.cacheDir ?? mkdtempSync(join(TEMP_ROOT, 'dsh-restart-cache-')),
@@ -922,7 +912,13 @@ describe('ShopGateway.restart', () => {
     expect(exit).not.toHaveBeenCalled()
   })
 
-  it("re-runs this process's own entry when dshBin is the bare default", async () => {
+  // POSIX-only, and the product is too: the two-phase handoff spawns `sh -c`
+  // with `kill -0`, `sleep` and `exec "$@"` (restart.ts), so this case cannot
+  // observe its marker on Windows however the platform option is set. The
+  // Windows behaviour is asserted rather than skipped — the two cases above
+  // pin `platform: 'win32'` and check the typed refusal and
+  // `restartSupported: false` — so nothing here is left uncovered by the skip.
+  it.skipIf(process.platform === 'win32')("re-runs this process's own entry when dshBin is the bare default", async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-node-'))
     const marker = join(dir, 'ran.log')
     const script = join(dir, 'fake-bin.js')
@@ -948,9 +944,7 @@ describe('ShopGateway.restart', () => {
 // profile manifest, catalog fixture, and the hot/loader injections.
 function gatewayOptions() {
   const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-guard-'))
-  const bin = join(dir, 'dsh')
-  writeFileSync(bin, `#!/bin/sh\necho "$1 $2 $3" >> "${join(dir, 'calls.log')}"\nexit 0\n`)
-  chmodSync(bin, 0o755)
+  const bin = fakeDshRecording(dir, 0, { silent: true })
   return {
     catalogUrl: 'https://shop.test/v1/',
     cacheDir: mkdtempSync(join(TEMP_ROOT, 'dsh-restart-guard-cache-')),
@@ -1076,14 +1070,7 @@ describe('ShopGateway.updateStart', () => {
       dsh: { profile: { bundles: ['dsh-plugin-shop'] } },
     }))
     const binDir = mkdtempSync(join(TEMP_ROOT, 'dsh-self-update-bin-'))
-    const bin = join(binDir, 'dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      `echo "$1 $2 $3 $4 $5" >> "${join(binDir, 'calls.log')}"`,
-      'exit 0',
-      '',
-    ].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = fakeDshRecording(binDir, 0, { silent: true })
     const gateway = new ShopGateway(stubCtx(), {
       catalogUrl: 'https://shop.test/v1/', cacheDir: '/cache', profile: 'web', profileDir: dir, dshBin: bin,
     })
@@ -1114,14 +1101,7 @@ describe('ShopGateway github entries', () => {
   }
 
   function gatewayWithRepo(dir: string): ShopGateway {
-    const bin = join(dir, 'fake-dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`,
-      'exit 0',
-      '',
-    ].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = fakeDshRecording(dir, 0, { silent: true })
     // The install flow reads the running profile manifest before spawning.
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-repo-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
@@ -1193,14 +1173,7 @@ describe('subpackage install spec', () => {
   }
 
   function gatewayWithSub(dir: string): ShopGateway {
-    const bin = join(dir, 'fake-dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`,
-      'exit 0',
-      '',
-    ].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = fakeDshRecording(dir, 0, { silent: true })
     // The install flow reads the running profile manifest before spawning.
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-sub-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
@@ -1224,7 +1197,18 @@ describe('subpackage install spec', () => {
       terminal = gateway.installStatus({ installId: result.installId })
     }
     expect(terminal.state).toBe('done')
-    expect(readFileSync(join(dir, 'calls.log'), 'utf8')).toContain(`plugin --profile web add github:someone/monorepo#${commit}&path:packages/sub-plugin`)
+    // The spec, as the downstream dsh actually receives it — which on Windows
+    // is quoted, because that is the only spelling that survives the shell
+    // dsh puts it through there (`shellSafeTarget`). The quoting rule itself
+    // is pinned with literal expectations for both platforms in
+    // `executor.test.ts`; this case is about the spec being COMPOSED from the
+    // snapshot's repo, commit and subdir, so it states the platform's
+    // spelling rather than asserting the POSIX one everywhere. The install
+    // path reads `process.platform`, not the gateway's `platform` option —
+    // that one only feeds the restart gate — so there is nothing to pin.
+    const spec = `github:someone/monorepo#${commit}&path:packages/sub-plugin`
+    const asDshSawIt = process.platform === 'win32' ? `"${spec}"` : spec
+    expect(readFileSync(join(dir, 'calls.log'), 'utf8')).toContain(`plugin --profile web add ${asDshSawIt}`)
     expect(JSON.parse(readFileSync(join(dir, 'cache/github-pins.json'), 'utf8'))).toEqual({ 'github:someone/monorepo#packages/sub-plugin': commit })
   })
 })
@@ -1246,14 +1230,7 @@ describe('release-rescued tarball install', () => {
   }
 
   function gatewayWithTarball(dir: string, fetchTarball: (url: string) => Promise<Response>): ShopGateway {
-    const bin = join(dir, 'fake-dsh')
-    writeFileSync(bin, [
-      '#!/bin/sh',
-      `echo "$1 $2 $3 $4 $5" >> "${join(dir, 'calls.log')}"`,
-      'exit 0',
-      '',
-    ].join('\n'))
-    chmodSync(bin, 0o755)
+    const bin = fakeDshRecording(dir, 0, { silent: true })
     // The install flow reads the running profile manifest before spawning.
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-tarball-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
@@ -1325,9 +1302,7 @@ describe('release-rescued tarball install', () => {
     // The npm path: the spec is `name@version`, no release asset involved.
     const npmEntry: CatalogEntry = { name: 'dsh-hello-plugin', version: '1.2.0', integrity: null, publishedAt: null, repository: null, license: 'MIT', tier: 'community', metadata: 'derived', source: 'npm', added: '2026-08-25' }
     const npmDir = mkdtempSync(join(TEMP_ROOT, 'dsh-npm-notarball-'))
-    const npmBin = join(npmDir, 'fake-dsh')
-    writeFileSync(npmBin, ['#!/bin/sh', `echo "$1 $2 $3 $4 $5" >> "${join(npmDir, 'calls.log')}"`, 'exit 0', ''].join('\n'))
-    chmodSync(npmBin, 0o755)
+    const npmBin = fakeDshRecording(npmDir, 0, { silent: true })
     const npmProfileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-npm-notarball-profile-'))
     writeFileSync(join(npmProfileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const npmGateway = new ShopGateway(stubCtx(), {
@@ -1348,9 +1323,7 @@ describe('release-rescued tarball install', () => {
       added: '2026-08-25',
     }
     const repoDir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-notarball-'))
-    const repoBin = join(repoDir, 'fake-dsh')
-    writeFileSync(repoBin, ['#!/bin/sh', `echo "$1 $2 $3 $4 $5" >> "${join(repoDir, 'calls.log')}"`, 'exit 0', ''].join('\n'))
-    chmodSync(repoBin, 0o755)
+    const repoBin = fakeDshRecording(repoDir, 0, { silent: true })
     const repoProfileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-github-notarball-profile-'))
     writeFileSync(join(repoProfileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const repoGateway = new ShopGateway(stubCtx(), {
@@ -1915,9 +1888,10 @@ describe('restart while an install is running (F-5)', () => {
     // duration of the operation. Restart must leave both that child and the
     // serving process alone until it has settled.
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-busy-'))
-    const slow = join(dir, 'dsh')
-    writeFileSync(slow, ['#!/bin/sh', 'sleep 2', 'exit 0', ''].join('\n'))
-    chmodSync(slow, 0o755)
+    const slow = fakeDsh(dir, [
+      'await new Promise(resolve => setTimeout(resolve, 2000))',
+      'process.exit(0)',
+    ].join('\n'))
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-busy-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: [] } }, dependencies: {} }))
     const listed: CatalogEntry = {
@@ -1951,9 +1925,7 @@ describe('restart while an install is running (F-5)', () => {
 
   it('allows the restart once the install has settled', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-idle-'))
-    const quick = join(dir, 'dsh')
-    writeFileSync(quick, ['#!/bin/sh', 'exit 0', ''].join('\n'))
-    chmodSync(quick, 0o755)
+    const quick = fakeDsh(dir, 'process.exit(0)')
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-idle-profile-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-web', dsh: { profile: { bundles: ['dsh-hello-plugin'] } }, dependencies: {} }))
     const listed: CatalogEntry = {
@@ -1965,6 +1937,13 @@ describe('restart while an install is running (F-5)', () => {
       catalogUrl: 'https://shop.test/v1/', cacheDir: mkdtempSync(join(TEMP_ROOT, 'dsh-restart-idle-cache-')),
       profile: 'web', profileDir, dshBin: quick, exit, restartArgv: ['web'],
       restartExitDelayMs: 1, restartParentPid: 1,
+      // Pinned like the guard cases above it: this one is about the INSTALL
+      // gate releasing, and inheriting the host platform would have Windows'
+      // restart refusal answer first and hide whether the gate released at
+      // all. The helper's own POSIX-only spawn fails asynchronously, after
+      // `restart()` has returned, and lands in restart.log where the stubbed
+      // `exit` leaves it harmless.
+      platform: 'linux',
       loadCatalog: async () => ({ snapshot: { schemaVersion: 6, builtAt: '', entries: [listed], denied: [], stars: {} }, stale: false }) as CatalogResult,
     })
     const started = await gateway.install({ name: 'dsh-hello-plugin', version: '1.2.0', acknowledged: true, source: 'npm' })

--- a/packages/dsh-plugin-shop/tests/host/profile.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/profile.test.ts
@@ -24,7 +24,14 @@ describe('discoverProfile', () => {
   it('resolves symlinks in the start path back to the real profile directory', () => {
     const dir = fixtureProfile()
     const link = join(dirname(dir), 'web-link')
-    symlinkSync(dir, link)
+    // A junction on Windows, where a directory SYMLINK needs elevation or
+    // Developer Mode and `symlinkSync` answers EPERM without either — which
+    // is why this one case failed there while the rest of the file passed. A
+    // junction needs no privilege, takes the same absolute target, and
+    // `realpathSync` resolves it identically, so the claim under test is
+    // unchanged. It is also the shape that actually occurs: pnpm links a
+    // workspace dependency as a junction on Windows for the same reason.
+    symlinkSync(dir, link, process.platform === 'win32' ? 'junction' : undefined)
     expect(discoverProfile(join(link, 'node_modules', 'dsh-plugin-shop', 'lib', 'index.js'))).toEqual({ name: 'web', dir })
   })
 

--- a/packages/dsh-plugin-shop/tests/host/restart.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/restart.test.ts
@@ -11,6 +11,11 @@ const TEMP_ROOT = fileTempRoot('restart')
 // A fixture `dsh` that records its argv in a marker file when it finally
 // runs — the marker's appearance is the proof the helper waited for the
 // parent pid and then exec'd the command.
+//
+// Still a `#!/bin/sh` script, deliberately, unlike every other fixture in
+// this suite: it is `exec`'d by the POSIX helper, and the two cases that use
+// it are the two that cannot run on Windows at all (see their skip). A node
+// script here would suggest the helper had become portable.
 function fixtureDsh(marker: string): string {
   const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-bin-'))
   const bin = join(dir, 'dsh')
@@ -25,6 +30,16 @@ function fixtureDsh(marker: string): string {
   return bin
 }
 
+/** The two cases that drive the handoff end to end. `startRestart` spawns
+ * `sh -c` with `kill -0`, `sleep` and `exec "$@"`, none of which Windows has
+ * — the gateway refuses a restart there before reaching this module at all
+ * (index.ts `restartPlatformSupported`, asserted in `index.test.ts`). So this
+ * is the product's own boundary rather than a fixture limitation, and the
+ * three cases below it DO run on Windows: the log-open refusal, the
+ * `restartCommand` arithmetic, and the helper-that-could-not-start log, which
+ * on Windows is not even hypothetical. */
+const posixHandoff = it.skipIf(process.platform === 'win32')
+
 async function until(predicate: () => boolean, timeoutMs: number): Promise<void> {
   const start = Date.now()
   while (!predicate()) {
@@ -33,15 +48,19 @@ async function until(predicate: () => boolean, timeoutMs: number): Promise<void>
   }
 }
 
-/** A pid that is already dead when the helper's first poll runs. */
+/** A pid that is already dead when the helper's first poll runs. The current
+ * node rather than `sh`: this is used by a case that DOES run on Windows,
+ * where a `spawn('sh', …)` resolves to a spawn failure whose pid is
+ * `undefined` — the case then passed while asserting nothing about a dead
+ * pid. */
 async function deadPid(): Promise<number> {
-  const gone = spawn('sh', ['-c', 'exit 0'])
+  const gone = spawn(process.execPath, ['-e', ''])
   await new Promise(resolve => gone.on('exit', resolve))
   return gone.pid!
 }
 
 describe('startRestart', () => {
-  it('execs the dsh command verbatim once the parent pid is gone, logging its output', async () => {
+  posixHandoff('execs the dsh command verbatim once the parent pid is gone, logging its output', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-case-'))
     const marker = join(dir, 'calls.log')
     const logFile = join(dir, 'restart.log')
@@ -58,7 +77,7 @@ describe('startRestart', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('holds the child back while the parent pid is alive', async () => {
+  posixHandoff('holds the child back while the parent pid is alive', async () => {
     const dir = mkdtempSync(join(TEMP_ROOT, 'dsh-restart-case-'))
     const marker = join(dir, 'calls.log')
     const sleeper = spawn('sh', ['-c', 'exec sleep 10'])


### PR DESCRIPTION
**What this changes, and why.**

The windows leg excluded four files by name — `executor`, `index`, `restart`,
`profile` — and 55 cases failed there for one shared reason. Their fake `dsh`
was a `#!/bin/sh` script written with `chmod 0o755`, and Windows has no form
of `spawn()` that starts one: no PE image for `CreateProcess`, and node has
refused `.cmd`/`.bat` without a shell since the 2024 batfile
argument-injection fix, so wrapping `sh` in a shim is not an escape either.

The fakes are node scripts now (`tests/fixtures/fake-dsh.ts`), spawned by the
same route production takes to the real CLI on Windows. `dshCommand` gains the
one rule that makes that work: a `dshBin` naming a `.js`/`.mjs`/`.cjs` entry
runs under `execPath`, on every platform.

That rule is not a Windows workaround and is not for the tests' benefit. Such
a file is not a runnable command anywhere — Windows wants a PE image, POSIX
wants a shebang plus an exec bit an entry shipped inside a package does not
reliably carry — and the npm-installed CLI's own entry IS this shape
(`bin: { dsh: 'lib/bin.js' }`), so it is what a caller pinning one
installation has to name. Before this it was an ENOEXEC. The bare-name branch
is untouched, and an explicitly named program still spawns as given: the
existing case pinning `C:\custom\dsh.cmd` still holds, and a new one pins that
`dsh-js`, `js` and `dsh.jsx` are programs rather than entries.

The `profile` symlink case is separate and smaller: a directory symlink needs
elevation or Developer Mode on Windows, so it takes a junction there —
privilege-free, same absolute target, same `realpathSync` result, and the
shape that actually occurs, since pnpm links a workspace dependency that way
for the same reason.

**Measured.** Windows 11, both suites: 996 root, and 777 passed / 4 skipped /
0 failed across all 30 package files, up from 723 / 1 / 55. Run through the
same command this leg now runs, `pnpm -C packages/dsh-plugin-shop test`, which
includes the live-harness e2e against a real dsh and chromium.

**About the four skips.** Each is a product boundary rather than a fixture that
could be fixed, and each says so where it stands: the POSIX-only restart
handoff (three — `startRestart` spawns `sh -c` with `kill -0`, `sleep` and
`exec "$@"`) and the POSIX spelling of the missing-CLI advice (one). Both have
their Windows arms asserted in the same files — the typed refusal and
`restartSupported: false` for the first, `spawnFailureDetail`'s platform
argument for the second — which is what makes a skip honest here rather than a
hole. Making the handoff portable is a change to what the host does with a
live port and belongs on its own, behind `beta`.

**Two real Windows facts the old fixtures could not reach**, both found by
running the converted files:

- `index`'s subpackage case asserted the BARE spec in the dsh argv, which is
  the POSIX spelling. On Windows `shellSafeTarget` quotes a spec carrying `&`,
  so the case now states the platform's spelling; the quoting rule itself
  stays pinned with literal both-platform expectations in `executor`.
- `restart`'s `deadPid()` spawned `sh` to obtain a dead pid. On Windows that is
  a spawn FAILURE whose pid is `undefined`, so the one case using it on that
  platform was passing while asserting nothing about a dead pid. It uses the
  current node.

The leg also stops spelling out two builds and calling vitest itself. That
divergence existed only to deliver the four `--exclude` flags — `pnpm test --`
would not pass them through — and there is nothing left to exclude, so it runs
the package's own `test` script and cannot drift from what a developer runs.

- [x] `pnpm test` and `pnpm typecheck` pass
- [x] The install pins in the four READMEs are untouched, unless this is a release commit
