### PR TITLE
fix(test): the fake dsh keeps its output, and an inner deadline can fire

### DIFF
--- a/packages/dsh-plugin-shop/tests/fixtures/fake-dsh.ts
+++ b/packages/dsh-plugin-shop/tests/fixtures/fake-dsh.ts
@@ -50,6 +50,34 @@ export function fakeDsh(dir: string, body: string, name = 'dsh.mjs'): string {
   writeFileSync(bin, [
     "import * as fs from 'node:fs'",
     'const argv = process.argv.slice(2)',
+    // `process.exit()` RECORDS the code and lets the body end, rather than
+    // terminating on the spot.
+    //
+    // stdout is a PIPE here, so node's writes to it are ASYNCHRONOUS, and
+    // `process.exit()` is documented to exit "even if there are still
+    // asynchronous operations pending ... including I/O to process.stdout".
+    // A body's exit is its last statement, so every line it printed is exactly
+    // what is at risk. While a reader keeps the pipe empty each write finishes
+    // inside `uv_write`'s first `write(2)` and nothing is ever queued — which
+    // is why an idle machine never sees this — but under a full parallel suite
+    // the reader is starved, the pipe backs up, and the queue is dropped.
+    // Measured: 171, 181 and 201 lines of 250 arriving on three different
+    // runs. Varying counts are what a lost race looks like; a logic error
+    // gives the same wrong answer every time.
+    //
+    // Recording the code instead lets the process end normally, which flushes
+    // stdout first. Verified against every body this fixture has: all sixteen
+    // `process.exit(n)` call sites are the LAST line of their body, so nothing
+    // depends on it not returning, and the two that spawn a grandchild
+    // `unref()` it, so nothing holds the loop open either.
+    //
+    // The synchronous alternative — writing to fd 1 with `fs.writeSync` — was
+    // tried first and is a trap. Node sets the pipe non-blocking as soon as
+    // anything TOUCHES `process.stdout`, so the override needed to install it
+    // is what makes the write it installs throw `EAGAIN` under the very
+    // back-pressure it was meant to survive.
+    'const recordExit = code => { process.exitCode = code === undefined ? 0 : code }',
+    'process.exit = recordExit',
     "const out = line => process.stdout.write(line + '\\n')",
     body,
     '',

--- a/packages/dsh-plugin-shop/tests/host/fake-dsh.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/fake-dsh.test.ts
@@ -8,6 +8,12 @@ import { fakeDsh } from '../fixtures/fake-dsh.ts'
 const TEMP_ROOT = mkdtempSync(join(tmpdir(), 'fake-dsh-fixture-'))
 afterAll(() => { rmSync(TEMP_ROOT, { recursive: true, force: true }) })
 
+interface Delivered {
+  readonly lines: number
+  /** The child's own stderr, so a CRASH is never mistaken for a truncation. */
+  readonly stderr: string
+}
+
 /**
  * Spawn `bin` and count the lines that actually arrive, with the reader
  * attached LATE.
@@ -24,23 +30,32 @@ afterAll(() => { rmSync(TEMP_ROOT, { recursive: true, force: true }) })
  * Draining late reproduces that starvation deterministically rather than
  * hoping to lose a race.
  */
-function spawnAndCount(bin: string, drainAfterMs: number): Promise<number> {
+function spawnAndCount(bin: string, drainAfterMs: number): Promise<Delivered> {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [bin], { stdio: ['ignore', 'pipe', 'ignore'] })
+    // stderr is CAPTURED, not ignored. A child that dies before writing
+    // anything and a child whose writes were dropped both deliver zero lines,
+    // and only its stderr tells them apart — the first version of this helper
+    // discarded it and turned a crash into a number that looked exactly like
+    // the defect under test.
+    const child = spawn(process.execPath, [bin], { stdio: ['ignore', 'pipe', 'pipe'] })
     const chunks: string[] = []
+    let stderr = ''
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => { stderr += chunk })
     child.stdout.setEncoding('utf8')
     child.stdout.pause()
+    // Resolve on the stdout stream's own `end`, never on `exit`/`close`. Those
+    // two can both fire before the timer below does — a child that crashes
+    // immediately does exactly that — and settling there resolves with an
+    // empty buffer the reader was never given a chance to fill. `end` is the
+    // only event that means "this stream is finished AND you have read it".
+    child.stdout.on('end', () => {
+      resolve({ lines: chunks.join('').split('\n').filter(line => line !== '').length, stderr })
+    })
     setTimeout(() => {
       child.stdout.on('data', (chunk: string) => chunks.push(chunk))
       child.stdout.resume()
     }, drainAfterMs)
-    let exited = false
-    let closed = false
-    const settle = (): void => {
-      if (exited && closed) resolve(chunks.join('').split('\n').filter(line => line !== '').length)
-    }
-    child.on('exit', () => { exited = true; settle() })
-    child.on('close', () => { closed = true; settle() })
   })
 }
 
@@ -55,7 +70,9 @@ describe('fakeDsh output survives the fixture\'s own exit', () => {
       'for (let i = 1; i <= 10000; i += 1) out(`line ${i}`)',
       'process.exit(0)',
     ].join('\n'))
-    expect(await spawnAndCount(bin, 200)).toBe(10000)
+    const got = await spawnAndCount(bin, 200)
+    expect(got.stderr, 'the child must not have died instead').toBe('')
+    expect(got.lines).toBe(10000)
   }, 30_000)
 
   it('delivers a direct process.stdout.write the same way', async () => {
@@ -67,7 +84,9 @@ describe('fakeDsh output survives the fixture\'s own exit', () => {
       "for (let i = 1; i <= 10000; i += 1) process.stdout.write('line ' + i + '\\n')",
       'process.exit(0)',
     ].join('\n'))
-    expect(await spawnAndCount(bin, 200)).toBe(10000)
+    const got = await spawnAndCount(bin, 200)
+    expect(got.stderr, 'the child must not have died instead').toBe('')
+    expect(got.lines).toBe(10000)
   }, 30_000)
 
   it('keeps the exit code the body asked for', async () => {

--- a/packages/dsh-plugin-shop/tests/host/fake-dsh.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/fake-dsh.test.ts
@@ -8,6 +8,20 @@ import { fakeDsh } from '../fixtures/fake-dsh.ts'
 const TEMP_ROOT = mkdtempSync(join(tmpdir(), 'fake-dsh-fixture-'))
 afterAll(() => { rmSync(TEMP_ROOT, { recursive: true, force: true }) })
 
+/**
+ * Far past what a pipe plus the parent's own read buffer can hold, so the
+ * child's writes MUST queue.
+ *
+ * The first version of this test used ten thousand lines (~88 KB), sized
+ * against a 64 KiB pipe alone. That was wrong: the parent buffers about
+ * another 64 KiB before it stops reading, so most of that volume fits in the
+ * combined space and never queues at all — measured, an UNFIXED fixture still
+ * delivered 6,637 of 10,000. At 200,000 lines (~2.4 MB) the same fixture
+ * delivers 6,836, and a fixed one delivers every line. That gap is the
+ * instrument; 10,000 lines did not have one.
+ */
+const LINES = 200_000
+
 interface Delivered {
   readonly lines: number
   /** The child's own stderr, so a CRASH is never mistaken for a truncation. */
@@ -15,20 +29,18 @@ interface Delivered {
 }
 
 /**
- * Spawn `bin` and count the lines that actually arrive, with the reader
- * attached LATE.
+ * Spawn `bin` and count the lines that actually arrive, with the pipe held
+ * shut until `drainAfterMs`.
  *
- * The delay is the whole instrument. `process.stdout.write` to a pipe is
+ * The delay is the instrument. `process.stdout.write` to a pipe is
  * ASYNCHRONOUS in node, and `process.exit()` does not flush what is still
  * queued — documented, and the reason this file exists. While a reader keeps
  * the pipe empty each write completes inside `uv_write`'s first `write(2)` and
  * nothing is ever queued, which is why the defect is invisible on an idle
  * machine and why it surfaced as a load-dependent flake instead: under a full
  * parallel suite the reader is starved, the pipe backs up, and the writes that
- * queued are dropped at exit.
- *
- * Draining late reproduces that starvation deterministically rather than
- * hoping to lose a race.
+ * queued are dropped at exit. Refusing to read reproduces that starvation on
+ * purpose rather than hoping to lose the race.
  */
 function spawnAndCount(bin: string, drainAfterMs: number): Promise<Delivered> {
   return new Promise((resolve) => {
@@ -43,36 +55,46 @@ function spawnAndCount(bin: string, drainAfterMs: number): Promise<Delivered> {
     child.stderr.setEncoding('utf8')
     child.stderr.on('data', (chunk: string) => { stderr += chunk })
     child.stdout.setEncoding('utf8')
+    // The consumer is registered BEFORE the pause, and this ordering is the
+    // whole difference between measuring the fixture and measuring ourselves.
+    //
+    // Node resumes a child's stdio streams when the child exits. On a paused
+    // stream that nobody is listening to, that resume DISCARDS everything
+    // buffered — measured: `end` fires on the exact millisecond of the child's
+    // exit and delivers 0 of 10,000 lines, while the identical child observed
+    // through the ordering below delivers all 10,000. So the earlier spelling
+    // (pause now, listen after the timer) reported total loss for every child
+    // that outran its own drain timer, whether or not the fixture was fixed —
+    // an assertion that cannot fail differently for the two things it is meant
+    // to tell apart. With a listener attached, `pause()` means "buffer this"
+    // instead of "throw it away", and the count is the child's alone.
+    child.stdout.on('data', (chunk: string) => chunks.push(chunk))
     child.stdout.pause()
     // Resolve on the stdout stream's own `end`, never on `exit`/`close`. Those
-    // two can both fire before the timer below does — a child that crashes
-    // immediately does exactly that — and settling there resolves with an
-    // empty buffer the reader was never given a chance to fill. `end` is the
-    // only event that means "this stream is finished AND you have read it".
+    // two can fire while bytes are still unread, and settling there resolves
+    // with a buffer nobody has drained. `end` is the only event that means
+    // "this stream is finished AND you have read it".
     child.stdout.on('end', () => {
       resolve({ lines: chunks.join('').split('\n').filter(line => line !== '').length, stderr })
     })
-    setTimeout(() => {
-      child.stdout.on('data', (chunk: string) => chunks.push(chunk))
-      child.stdout.resume()
-    }, drainAfterMs)
+    // Releasing the pipe is what lets a CORRECT fixture finish: it cannot
+    // flush 2.4 MB into a pipe nobody is emptying, so it waits here. A broken
+    // one has already exited and dropped its queue by now — the pipe fills
+    // within the first few milliseconds, so this delay is ~50x longer than the
+    // back-pressure needs to build.
+    setTimeout(() => { child.stdout.resume() }, drainAfterMs)
   })
 }
 
 describe('fakeDsh output survives the fixture\'s own exit', () => {
   it('delivers every line even when the reader drains late', async () => {
-    // Ten thousand lines is past a 64 KiB pipe on purpose: under the buffer
-    // nothing has to queue, and the defect cannot be observed at all. Past it,
-    // an asynchronous write MUST queue, and `process.exit(0)` MUST drop the
-    // queue — measured 6 runs of 6 losing every line before the fix, against
-    // 6 of 6 complete after it.
     const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'volume-')), [
-      'for (let i = 1; i <= 10000; i += 1) out(`line ${i}`)',
+      `for (let i = 1; i <= ${LINES}; i += 1) out(\`line \${i}\`)`,
       'process.exit(0)',
     ].join('\n'))
     const got = await spawnAndCount(bin, 200)
     expect(got.stderr, 'the child must not have died instead').toBe('')
-    expect(got.lines).toBe(10000)
+    expect(got.lines).toBe(LINES)
   }, 30_000)
 
   it('delivers a direct process.stdout.write the same way', async () => {
@@ -81,12 +103,12 @@ describe('fakeDsh output survives the fixture\'s own exit', () => {
     // only the helper would leave those exposed, so the seam has to be the
     // stream itself.
     const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'direct-')), [
-      "for (let i = 1; i <= 10000; i += 1) process.stdout.write('line ' + i + '\\n')",
+      `for (let i = 1; i <= ${LINES}; i += 1) process.stdout.write('line ' + i + '\\n')`,
       'process.exit(0)',
     ].join('\n'))
     const got = await spawnAndCount(bin, 200)
     expect(got.stderr, 'the child must not have died instead').toBe('')
-    expect(got.lines).toBe(10000)
+    expect(got.lines).toBe(LINES)
   }, 30_000)
 
   it('keeps the exit code the body asked for', async () => {

--- a/packages/dsh-plugin-shop/tests/host/fake-dsh.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/fake-dsh.test.ts
@@ -1,0 +1,86 @@
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { fakeDsh } from '../fixtures/fake-dsh.ts'
+
+const TEMP_ROOT = mkdtempSync(join(tmpdir(), 'fake-dsh-fixture-'))
+afterAll(() => { rmSync(TEMP_ROOT, { recursive: true, force: true }) })
+
+/**
+ * Spawn `bin` and count the lines that actually arrive, with the reader
+ * attached LATE.
+ *
+ * The delay is the whole instrument. `process.stdout.write` to a pipe is
+ * ASYNCHRONOUS in node, and `process.exit()` does not flush what is still
+ * queued — documented, and the reason this file exists. While a reader keeps
+ * the pipe empty each write completes inside `uv_write`'s first `write(2)` and
+ * nothing is ever queued, which is why the defect is invisible on an idle
+ * machine and why it surfaced as a load-dependent flake instead: under a full
+ * parallel suite the reader is starved, the pipe backs up, and the writes that
+ * queued are dropped at exit.
+ *
+ * Draining late reproduces that starvation deterministically rather than
+ * hoping to lose a race.
+ */
+function spawnAndCount(bin: string, drainAfterMs: number): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [bin], { stdio: ['ignore', 'pipe', 'ignore'] })
+    const chunks: string[] = []
+    child.stdout.setEncoding('utf8')
+    child.stdout.pause()
+    setTimeout(() => {
+      child.stdout.on('data', (chunk: string) => chunks.push(chunk))
+      child.stdout.resume()
+    }, drainAfterMs)
+    let exited = false
+    let closed = false
+    const settle = (): void => {
+      if (exited && closed) resolve(chunks.join('').split('\n').filter(line => line !== '').length)
+    }
+    child.on('exit', () => { exited = true; settle() })
+    child.on('close', () => { closed = true; settle() })
+  })
+}
+
+describe('fakeDsh output survives the fixture\'s own exit', () => {
+  it('delivers every line even when the reader drains late', async () => {
+    // Ten thousand lines is past a 64 KiB pipe on purpose: under the buffer
+    // nothing has to queue, and the defect cannot be observed at all. Past it,
+    // an asynchronous write MUST queue, and `process.exit(0)` MUST drop the
+    // queue — measured 6 runs of 6 losing every line before the fix, against
+    // 6 of 6 complete after it.
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'volume-')), [
+      'for (let i = 1; i <= 10000; i += 1) out(`line ${i}`)',
+      'process.exit(0)',
+    ].join('\n'))
+    expect(await spawnAndCount(bin, 200)).toBe(10000)
+  }, 30_000)
+
+  it('delivers a direct process.stdout.write the same way', async () => {
+    // `out` is not the only spelling a body uses: several fixtures call
+    // `process.stdout.write` directly for the unterminated-line cases. Fixing
+    // only the helper would leave those exposed, so the seam has to be the
+    // stream itself.
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'direct-')), [
+      "for (let i = 1; i <= 10000; i += 1) process.stdout.write('line ' + i + '\\n')",
+      'process.exit(0)',
+    ].join('\n'))
+    expect(await spawnAndCount(bin, 200)).toBe(10000)
+  }, 30_000)
+
+  it('keeps the exit code the body asked for', async () => {
+    // The fix must not change what `process.exit(n)` means. Sixteen call sites
+    // depend on the code, and several assert a failure path.
+    const bin = fakeDsh(mkdtempSync(join(TEMP_ROOT, 'code-')), [
+      "out('one')",
+      'process.exit(3)',
+    ].join('\n'))
+    const code = await new Promise<number | null>((resolve) => {
+      const child = spawn(process.execPath, [bin], { stdio: ['ignore', 'ignore', 'ignore'] })
+      child.on('exit', c => resolve(c))
+    })
+    expect(code).toBe(3)
+  })
+})

--- a/packages/dsh-plugin-shop/vitest.config.ts
+++ b/packages/dsh-plugin-shop/vitest.config.ts
@@ -6,5 +6,19 @@ export default defineConfig({
     // package's vitest run (P2 exit criterion); the default include pattern
     // only matches *.test.* and *.spec.*.
     include: ['tests/**/*.{test,spec,e2e}.?(c|m)[jt]s?(x)'],
+    // Above every deadline the host tests set for THEMSELVES, which vitest's
+    // 5 s default sat underneath. Ten `Date.now() + 5000`/`+ 15000` polling
+    // loops in `index.test.ts` could therefore never reach their own
+    // expiry — the harness killed the test first, so each one was dead code
+    // and every slow run reported `Test timed out in 5000ms` instead of the
+    // assertion that was actually unmet. An inner deadline is only a check if
+    // the outer budget lets it fire.
+    //
+    // Load is what made that matter. These tests spawn a real CLI per install
+    // — 33 of them in the eviction case, 3.3 s when it runs alone — so the
+    // margin under 5 s was about a second, and a full parallel suite spends it.
+    // The cost of the larger budget is a genuinely wedged test taking longer
+    // to report, and the inner deadlines are what keep that bounded.
+    testTimeout: 30_000,
   },
 })


### PR DESCRIPTION
Two defects, both landed by the same port and both invisible on an idle machine. `plugin` on `main` failed on `6c02a18` with `expected 'line 201' to be 'line 250'`; a rerun passed, and that rerun was the race winning, not the bug being absent.

#36 moved these host tests off mocks onto a real spawned `dsh.mjs`. That was right — a `#!/bin/sh` fixture cannot start on Windows. It also changed two magnitudes that nothing followed up on: **the output path became a pipe**, and **one test went from milliseconds to seconds**.

## 1. The fixture lost its own output

`process.stdout.write` to a pipe is asynchronous, and `process.exit()` is documented to exit *"even if there are still asynchronous operations pending … including I/O to process.stdout"*. A body's exit is its last statement, so everything it printed is exactly what is at risk.

**Why only under load.** libuv's `uv_write` attempts an immediate `write(2)` and only queues on EAGAIN. While a reader keeps the pipe empty nothing ever queues — so an idle machine cannot observe this at all. Under a full parallel suite the reader is starved, the pipe backs up, and the queue is dropped at exit.

Measured with a 24-child probe:

```
process.exit(0)   24 runs   lost data in 2   counts 171, 231, 250
natural exit      24 runs   lost data in 0   counts 250
```

`171` is one of the exact values the failing test reported. Across three observations the counts were **171, 181, 201 of 250** — varying counts are what a lost race looks like; a logic error gives the same wrong answer every time.

**The fix:** `process.exit` records the code and lets the body end, so node flushes stdout before exiting. Checked rather than assumed — all sixteen call sites are the **last line** of their body, so nothing depends on it not returning, and the two that spawn a grandchild `unref()` it, so nothing holds the loop open.

**The synchronous alternative is a trap, and it is worth naming.** Writing to fd 1 with `fs.writeSync` works — in a probe that never touches `process.stdout`. Node sets the pipe non-blocking as soon as anything *touches* that stream, so the override needed to install the sync path is what makes the sync path throw `EAGAIN` under the very back-pressure it was meant to survive. Tried first; the fixture then emitted nothing at all.

## 2. Ten inner deadlines were dead code

`index.test.ts` polls with `Date.now() + 5000` and `+ 15000` in ten places, inside vitest's default 5 s budget. **Not one could reach its own expiry** — the harness killed the test first.

The cost is not slowness. It is that every slow run reported `Test timed out in 5000ms` instead of the assertion that was actually unmet, so the failure said nothing about what went wrong. An inner deadline is only a check if the outer budget lets it fire.

`testTimeout` now sits above all ten. The same load explains why this surfaced together with the first defect: the eviction case spawns 33 real CLIs and takes **3.3 s alone**, leaving about a second of margin that a parallel suite spends. Under the contended run below it reached **17.6 s** — 3.5× past the old default.

## Verification

Controlled comparison — same worktree, same full suite, three runs each, toggling only the fixture:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| without the fix | 4 failed | 3 failed | 3 failed |
| with the fix | **0 failed** | **0 failed** | **0 failed** |

CI is the authority here, and it has now confirmed both fixes directly: on `276fb6b` every file this PR set out to repair passed — `executor` 67/67, `index` 102/102 at 5086 ms, `restart` 7/7, and `apply.client.spec.tsx` (which cannot collect in a worktree) 8/8.

## The regression test needed two corrections of its own

`tests/host/fake-dsh.test.ts` is new. Its first version failed in CI while everything it was guarding passed, and it was wrong in two independent ways — both now fixed, and both worth stating because the first version's claims are withdrawn.

**It measured itself, not the fixture.** Node resumes a child's stdio streams when the child exits; on a paused stream nobody is listening to, that resume *discards* the buffer. The helper paused first and attached its reader on a timer, so any child that outran the timer reported total loss whether or not the fixture was fixed. Same child, 10,000 lines, toggling only the listener's position:

```
pause, then listen ->      0 / 10000   exit@111 end@111
listen, then pause ->  10000 / 10000   exit@107 end@108
```

`end` firing on the exact millisecond of the exit is the tell. The listener now goes on first, where `pause()` means "buffer this" rather than "throw it away".

**The volume was sized against the wrong buffer.** 10,000 lines (~88 KB) was sized against a 64 KiB pipe alone; the parent buffers ~64 KiB more before it stops reading, so most of it never has to queue. With the listener fixed, an *unfixed* fixture still delivers 6,637 of 10,000 — no clean signal to assert on. At **200,000 lines (~2.4 MB)** an unfixed fixture delivers 6,838 and a fixed one delivers all 200,000.

So the earlier claim that the test "pins the defect deterministically rather than by hoping to lose a race" was false as written: at 10,000 lines it raced in the *opposite* direction, passing only when the child was slow enough to still be alive at the drain. That is precisely why it passed on Windows (576 ms) and on a loaded worktree, and failed on a fast Linux runner. At 200,000 lines no pipe on any OS absorbs the volume, so the child cannot finish flushing into a pipe nobody is emptying and the outcome no longer depends on who wins. Verified by mutation — disabling the fixture fix yields `expected 6838 to be 200000`, a number that can only mean a dropped queue, where the old harness reported a `+0` that meant nothing in particular.

Under the full suite on a contended machine all four affected files pass, `fake-dsh` taking 4.3 s against 685 ms alone.

## One thing this worktree could not check

`apply.client.spec.tsx` needs a built `lib/`, and the vendored protocol package has no types in a worktree, so that file fails to collect; `web-full-flow.e2e.ts` fails here too, in isolation as well as in the suite, on a local `dsh web` that exits before printing its URL. **Both fail identically with and without these changes**, so the comparison above holds, and CI runs both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
