### PR TITLE
fix(e2e): the loader selectors follow the harness to 0.1.5-rc.1

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -47,16 +47,28 @@ jobs:
       # Pinned to the harness the e2e's DOM contract is written against, NOT to
       # the workspace's own lockfile (which still resolves the harness dev deps
       # at 0.1.1-rc.2 — a separate, deliberate pin). This global install is what
-      # serves the web UI the e2e drives, and the two versions render mutually
-      # exclusive contracts. Measured 2026-09-04 in
+      # serves the web UI the e2e drives, and the versions render mutually
+      # exclusive contracts. Measured in
       # @deepseek-ai/dsh-client-ui-settings-plugin-inventory:
       #   0.1.1-rc.2  data-enabled x2, data-kind x0, no 全局插件 section
       #   0.1.2-rc.1  data-enabled x0, data-kind x5, 插件列表 split in two with
       #               the Loader plane COLLAPSED when a preset roster exists
-      # So a selector suite can satisfy one and only one of them. It is written
-      # against 0.1.2-rc.1 because that is what users install today; when this
-      # pin moves again, expect web-full-flow.e2e.ts to move with it.
-      - run: npm install -g @deepseek-ai/dsh@0.1.2-rc.1
+      #   0.1.5-rc.1  data-kind x0 AND data-phase x0 — the enabled tag and the
+      #               phase dot are now rendered by the shared primitives
+      #               (Tag, StateDot) as data-tone / data-state, and those live
+      #               in dsh-client-ui-primitives, which the web frontend
+      #               BUNDLES rather than installing as a package in the harness
+      #               tree. So a census of this package alone reads "the
+      #               instrument was deleted" while the DOM still carries it
+      #               under another name; the mapping is on the contract comment
+      #               at the top of web-full-flow.e2e.ts. The rest of the
+      #               attribute census is unchanged, and the entry card's own
+      #               attributes are byte-identical across the two.
+      # Names, not counts, are what a selector suite can satisfy one version of
+      # at a time. It is written against 0.1.5-rc.1 because that is what users
+      # install today; when this pin moves again, expect web-full-flow.e2e.ts
+      # to move with it.
+      - run: npm install -g @deepseek-ai/dsh@0.1.5-rc.1
       - run: dsh --version
       # The web full-flow e2e (P2 exit criterion) needs a playwright browser;
       # without --with-deps for now — the ubuntu-latest image already carries

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -48,26 +48,31 @@ jobs:
       # the workspace's own lockfile (which still resolves the harness dev deps
       # at 0.1.1-rc.2 — a separate, deliberate pin). This global install is what
       # serves the web UI the e2e drives, and the versions render mutually
-      # exclusive contracts. Measured in
-      # @deepseek-ai/dsh-client-ui-settings-plugin-inventory:
+      # exclusive contracts. Raw grep hits over
+      # @deepseek-ai/dsh-client-ui-settings-plugin-inventory's lib/client.js,
+      # inlined CSS included — so a count is not a count of JSX sites and only
+      # the zero/non-zero split is load-bearing. Each row carries the date it
+      # was taken, because an undated census cannot be aged out:
       #   0.1.1-rc.2  data-enabled x2, data-kind x0, no 全局插件 section
+      #               (measured 2026-09-04)
       #   0.1.2-rc.1  data-enabled x0, data-kind x5, 插件列表 split in two with
       #               the Loader plane COLLAPSED when a preset roster exists
+      #               (measured 2026-09-04)
       #   0.1.5-rc.1  data-kind x0 AND data-phase x0 — the enabled tag and the
-      #               phase dot are now rendered by the shared primitives
-      #               (Tag, StateDot) as data-tone / data-state, and those live
-      #               in dsh-client-ui-primitives, which the web frontend
-      #               BUNDLES rather than installing as a package in the harness
-      #               tree. So a census of this package alone reads "the
-      #               instrument was deleted" while the DOM still carries it
-      #               under another name; the mapping is on the contract comment
-      #               at the top of web-full-flow.e2e.ts. The rest of the
-      #               attribute census is unchanged, and the entry card's own
-      #               attributes are byte-identical across the two.
+      #               phase dot moved onto shared primitives that the web
+      #               frontend BUNDLES rather than installing as a package, so
+      #               a census of this package alone reads "the instrument was
+      #               deleted" while the DOM still carries it. The <li> entry
+      #               card's own four attributes — data-plugin-entry,
+      #               data-plugin-module, data-failed, data-open — are unchanged
+      #               from 0.1.2-rc.1. Its CHILDREN are not, and that is the
+      #               half that cost two debugging rounds (measured 2026-09-10)
       # Names, not counts, are what a selector suite can satisfy one version of
-      # at a time. It is written against 0.1.5-rc.1 because that is what users
-      # install today; when this pin moves again, expect web-full-flow.e2e.ts
-      # to move with it.
+      # at a time. The census is what makes this pin auditable; what the e2e
+      # actually READS is not restated here, because it is no longer these
+      # attributes at all — web-full-flow.e2e.ts's contract header owns that,
+      # and repo-guards.test.ts fails the build if this pin and that header
+      # name different harness versions.
       - run: npm install -g @deepseek-ai/dsh@0.1.5-rc.1
       - run: dsh --version
       # The web full-flow e2e (P2 exit criterion) needs a playwright browser;

--- a/docs/design/2026-09-01-harness-compatibility.md
+++ b/docs/design/2026-09-01-harness-compatibility.md
@@ -272,14 +272,13 @@ satisfies(found, range, { includePrerelease: true })
 ```
 
 **`includePrerelease` is load-bearing.** The harness ships nothing but
-`-rc` versions, so strict semver rejects every one of them, including the
-version that is installed and works. Measured against `^0.1.1-rc.2`:
+`-rc` versions, so strict semver rejects every one of them, including
+whichever one is installed and working. Measured against `^0.1.1-rc.2`:
 
 | Version | strict | includePrerelease | What it is |
 |---|---|---|---|
-| `0.1.2-rc.1` | violates | satisfies | installed 2026-09-04, works fine |
-| `0.1.5-rc.1` | violates | satisfies | installed 2026-09-10 (npm `latest`), works fine |
-| `0.1.9-rc.3` | violates | satisfies | a later rc on the same minor line |
+| `0.1.5-rc.1` | violates | satisfies | the install — npm `latest`, measured 2026-09-10, works fine |
+| `0.1.9-rc.3` | violates | satisfies | hypothetical: a later rc on the same minor line. Published nowhere — it stands for whatever the next rc is, so this row survives a re-measurement of the one above |
 | `0.1.1-rc.1` | violates | violates | older than pinned |
 | `0.2.0-rc.1` | violates | violates | minor-line move — the real breaking change |
 | `1.0.0` | violates | violates | major-line move |

--- a/docs/design/2026-09-01-harness-compatibility.md
+++ b/docs/design/2026-09-01-harness-compatibility.md
@@ -277,7 +277,8 @@ version that is installed and works. Measured against `^0.1.1-rc.2`:
 
 | Version | strict | includePrerelease | What it is |
 |---|---|---|---|
-| `0.1.2-rc.1` | violates | satisfies | installed now, works fine |
+| `0.1.2-rc.1` | violates | satisfies | installed 2026-09-04, works fine |
+| `0.1.5-rc.1` | violates | satisfies | installed 2026-09-10 (npm `latest`), works fine |
 | `0.1.9-rc.3` | violates | satisfies | a later rc on the same minor line |
 | `0.1.1-rc.1` | violates | violates | older than pinned |
 | `0.2.0-rc.1` | violates | violates | minor-line move — the real breaking change |

--- a/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
+++ b/docs/plans/2026-09-03-audit-fix-e-test-gaps.md
@@ -1802,6 +1802,8 @@ Closed by `2184265`: an `expandGlobalPlane` helper opens the 全局插件 disclo
 
 > **Reviewed 2026-09-05 — no work, as recorded.** Left as the standing hazard it describes: `plugin.yml`'s pin to `0.1.2-rc.1` and its measured contract table are still the only thing holding the e2e's selectors to a harness contract this repository does not own.
 
+> **Fired a second time, 2026-09-10 — PR #39.** `0.1.5-rc.1` refactored `StateTag`/`PhaseDot` onto the shared `Tag`/`StateDot` primitives; `[data-kind=enabled]` and `[data-phase=active]` both went to x0 and the same two cases timed out again. Two data points, not one, so the hazard is a rate rather than an incident, and the fix this time was structural rather than another rename: the selectors moved OFF the design system's private `data-*` and onto the accessibility contract (`role=img` named by the localized phase, the card button's `aria-label`), which the harness cannot churn without a user-visible change, and `repo-guards.test.ts` now fails when `plugin.yml`'s pin and the e2e's contract header name different harness versions. The pin is `0.1.5-rc.1`; the sentence above describes the state on 2026-09-05.
+
 ---
 
 ### Task 13: H-11 — the temp-home leak is in the host tests, not in the e2e file the finding names

--- a/packages/dsh-plugin-shop/src/host/peers.ts
+++ b/packages/dsh-plugin-shop/src/host/peers.ts
@@ -141,9 +141,11 @@ export function nodeVersionResolver(baseUrl: string): PeerVersionResolver {
  *
  * `includePrerelease` is load-bearing, not a convenience. The harness ships
  * nothing but `-rc` versions, so under strict semver `^0.1.1-rc.2` excludes
- * `0.1.2-rc.1` — the version that is installed and works — and every future
- * rc bump would raise a false alarm. With it on, the range still excludes an
- * older prerelease (`0.1.1-rc.1`) and a minor- or major-line move
+ * every later rc on the same 0.1 line — including whichever one is installed
+ * and working, named as a property because that version moves and a comment
+ * naming it goes stale in place — and every future rc bump would raise a
+ * false alarm. With it on, the range still excludes an older prerelease
+ * (`0.1.1-rc.1`) and a minor- or major-line move
  * (`0.2.0-rc.1`, `1.0.0`), which are the moves that actually break a plugin
  * path. Discrimination on both sides is the whole point: one false warning
  * teaches a reader to ignore every warning.

--- a/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
+++ b/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
@@ -70,8 +70,13 @@
  *   entries), and the second is COLLAPSED whenever a preset roster exists.
  *   A collapsed section renders no `<li>` at all, so every Loader selector is
  *   ABSENT rather than hidden. Each card is then
- *   `[data-plugin-entry=<entryId>]` with the enabled tag `[data-kind=enabled]`
- *   and the phase dot `[data-phase=active]`
+ *   `[data-plugin-entry=<entryId>]` with the enabled tag `[data-tone=success]`
+ *   and the phase dot `[data-state=done]`. Both attribute names moved with
+ *   harness 0.1.5-rc.1, which refactored `StateTag`/`PhaseDot` onto the shared
+ *   `Tag`/`StateDot` primitives and dropped the `data-kind`/`data-phase` the
+ *   hand-rolled spans used to emit; the primitives carry the MAPPED value
+ *   instead (`TAG_TONES`, `PHASE_DOT_STATES`), so the assertion reads the same
+ *   fact through a different attribute rather than a weakened one.
  * - settings modal close: `.VOzbGW_close` (visually-hidden label 关闭)
  */
 
@@ -89,8 +94,10 @@ import { startInstall } from '../../src/host/executor.ts'
  *
  * Harness 0.1.2-rc.1 split that tab in two — agent presets first, then the
  * global plane — and collapses the global plane whenever a preset roster is
- * composed, which the `web` profile always has. A collapsed section renders no
- * `<li>`, so `[data-plugin-entry]` and `[data-phase]` are absent, not hidden:
+ * composed, which the `web` profile always has. Both halves of that survive
+ * unchanged into 0.1.5-rc.1, whose `data-plugin-entry` cards this waits on.
+ * A collapsed section renders no
+ * `<li>`, so `[data-plugin-entry]` and `[data-state]` are absent, not hidden:
  * every assertion below this point either times out or, worse, passes
  * vacuously. The three `count()).toBe(0)` "nothing is live" checks are exactly
  * that hazard — an empty collapsed section satisfies them for free.
@@ -677,8 +684,8 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await expandGlobalPlane(dialog)
       const liveEntry = dialog.locator('[data-plugin-entry="include:typert-gateway:mkt-e2e-live"]')
       await liveEntry.waitFor({ state: 'visible', timeout: 15_000 })
-      await liveEntry.locator('[data-kind="enabled"]').waitFor({ state: 'visible' })
-      await liveEntry.locator('[data-phase="active"]').waitFor({ state: 'visible' })
+      await liveEntry.locator('[data-tone="success"]').waitFor({ state: 'visible' })
+      await liveEntry.locator('[data-state="done"]').waitFor({ state: 'visible' })
 
       // The settled mutation re-reads installed() in place. Switching back
       // to the already-mounted shop must expose the installed actions without
@@ -740,7 +747,7 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await dialog3.getByRole('button', { name: '插件', exact: true }).click()
       await dialog3.getByRole('tab', { name: '插件列表' }).click()
       await expandGlobalPlane(dialog3)
-      await dialog3.locator('[data-phase]').first().waitFor({ state: 'visible', timeout: 15_000 })
+      await dialog3.locator('[data-state]').first().waitFor({ state: 'visible', timeout: 15_000 })
       expect(await dialog3.locator('[data-plugin-entry="include:typert-gateway:mkt-e2e-live"]').count()).toBe(0)
     },
     120_000,
@@ -800,7 +807,7 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await dialog2.getByRole('button', { name: '插件', exact: true }).click()
       await dialog2.getByRole('tab', { name: '插件列表' }).click()
       await expandGlobalPlane(dialog2)
-      await dialog2.locator('[data-phase]').first().waitFor({ state: 'visible', timeout: 15_000 })
+      await dialog2.locator('[data-state]').first().waitFor({ state: 'visible', timeout: 15_000 })
       expect(await dialog2.locator('[data-plugin-entry="include:typert-gateway:mkt-e2e-config"]').count()).toBe(0)
     },
     120_000,

--- a/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
+++ b/packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts
@@ -40,6 +40,13 @@
  * Skipped unless the machine has both the real `dsh` CLI on PATH and a
  * playwright chromium installed (CI installs both; see .github/workflows).
  *
+ * Written against harness 0.1.5-rc.1 — the version `.github/workflows/plugin.yml`
+ * installs globally, and therefore the one every selector below was measured
+ * on. The two are held together mechanically: `repo-guards.test.ts` fails the
+ * build if this line and that pin name different versions — the pin has moved
+ * twice already, and both times the mismatch surfaced as an opaque timeout
+ * rather than as a diff someone could read.
+ *
  * Pinned selectors (all verified against the live app, zh-CN):
  * - the app root frame: `[class*="frame"]` — the frame class is CSS-module
  *   hashed, and the live app's root element carries a class containing `frame`
@@ -66,17 +73,32 @@
  * - uninstall: `[data-shop-uninstall]`; done view `[data-shop-uninstall-done]`
  * - loader inventory tab: `dialog.getByRole('tab', { name: '插件列表' })`, then
  *   `expandGlobalPlane` — the tab splits into 会话插件 (the selected agent
- *   preset's composition rows: bare ids, no phase dot) and 全局插件 (the Loader
- *   entries), and the second is COLLAPSED whenever a preset roster exists.
- *   A collapsed section renders no `<li>` at all, so every Loader selector is
- *   ABSENT rather than hidden. Each card is then
- *   `[data-plugin-entry=<entryId>]` with the enabled tag `[data-tone=success]`
- *   and the phase dot `[data-state=done]`. Both attribute names moved with
- *   harness 0.1.5-rc.1, which refactored `StateTag`/`PhaseDot` onto the shared
- *   `Tag`/`StateDot` primitives and dropped the `data-kind`/`data-phase` the
- *   hand-rolled spans used to emit; the primitives carry the MAPPED value
- *   instead (`TAG_TONES`, `PHASE_DOT_STATES`), so the assertion reads the same
- *   fact through a different attribute rather than a weakened one.
+ *   preset's composition rows) and 全局插件 (the Loader entries), and the second
+ *   is COLLAPSED whenever a preset roster exists. The `include:` prefix on the
+ *   entry id is what separates the two planes, and it is the ONLY thing that
+ *   does: a preset row's id comes from `compositionInventory()` rather than
+ *   `pluginEntryId()`, but it renders the same card through the same
+ *   `PluginCard`, phase dot included once its roster is mounted. So a Loader
+ *   card is ABSENT rather than hidden while the plane is shut — but the preset
+ *   plane above it stays open, and its cards keep answering an unprefixed
+ *   `[data-plugin-entry]` and every dot selector.
+ *   Each Loader card is `[data-plugin-entry=<entryId>]`, and its enabled tag
+ *   and phase dot are read through the ACCESSIBILITY contract: the tag through
+ *   the card button's `aria-label` (`<title>, <entryId>, 已启用`) and the dot
+ *   through `role=img` named by the localized phase (运行中 for active; the
+ *   inner `StateDot` is `aria-hidden` and contributes nothing).
+ *   NOT through the tag's and dot's own data attributes. Those belong to the
+ *   design system rather than to the inventory, and they have now moved twice
+ *   underneath this file — `data-enabled=true`, then `data-kind=enabled` and
+ *   `data-phase=active` at 0.1.2-rc.1, then `data-tone=success` and
+ *   `data-state=done` at 0.1.5-rc.1, when `StateTag`/`PhaseDot` were refactored
+ *   onto the shared `Tag`/`StateDot` primitives — each move costing a debugging
+ *   round for a rename that changed nothing a user can see. The accessible
+ *   names are also the sharper read of the two: `PHASE_DOT_STATES` folds
+ *   `loading` and `unloading` onto one `data-state=ongoing`, and it is emitted
+ *   by a `StateDot` that eleven harness packages render (measured 2026-09-10,
+ *   this one among them), where the label is 1:1 with the phase and is the
+ *   inventory's own.
  * - settings modal close: `.VOzbGW_close` (visually-hidden label 关闭)
  */
 
@@ -94,13 +116,19 @@ import { startInstall } from '../../src/host/executor.ts'
  *
  * Harness 0.1.2-rc.1 split that tab in two — agent presets first, then the
  * global plane — and collapses the global plane whenever a preset roster is
- * composed, which the `web` profile always has. Both halves of that survive
- * unchanged into 0.1.5-rc.1, whose `data-plugin-entry` cards this waits on.
- * A collapsed section renders no
- * `<li>`, so `[data-plugin-entry]` and `[data-state]` are absent, not hidden:
- * every assertion below this point either times out or, worse, passes
- * vacuously. The three `count()).toBe(0)` "nothing is live" checks are exactly
- * that hazard — an empty collapsed section satisfies them for free.
+ * composed, which the `web` profile always has. Both halves survive unchanged
+ * into 0.1.5-rc.1. A collapsed section renders no `<li>`, so a Loader card is
+ * absent rather than hidden: every assertion below this point either times out
+ * or, worse, passes vacuously. The two dialog-scoped `count()).toBe(0)`
+ * "nothing is live" checks are exactly that hazard — an empty collapsed
+ * section satisfies them for free. (The other `count()).toBe(0)` assertions in
+ * this file are scoped to a shop card, which this disclosure cannot empty.)
+ *
+ * What it must NOT be guarded with is a bare dot or entry selector: the preset
+ * plane is open by default and renders both, so `[data-plugin-entry]` and
+ * `[data-state]` are satisfied with the Loader plane still shut. Anything
+ * downstream that needs "the Loader snapshot rendered" already has it from
+ * this helper's postcondition and must not re-derive it more weakly.
  *
  * Expanded through its own disclosure and NOT the 搜索插件 box: search also
  * FILTERS the list, which would make those same "nothing is live" assertions
@@ -684,8 +712,8 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await expandGlobalPlane(dialog)
       const liveEntry = dialog.locator('[data-plugin-entry="include:typert-gateway:mkt-e2e-live"]')
       await liveEntry.waitFor({ state: 'visible', timeout: 15_000 })
-      await liveEntry.locator('[data-tone="success"]').waitFor({ state: 'visible' })
-      await liveEntry.locator('[data-state="done"]').waitFor({ state: 'visible' })
+      await liveEntry.getByRole('button', { name: /已启用/ }).waitFor({ state: 'visible', timeout: 15_000 })
+      await liveEntry.getByRole('img', { name: '运行中' }).waitFor({ state: 'visible', timeout: 15_000 })
 
       // The settled mutation re-reads installed() in place. Switching back
       // to the already-mounted shop must expose the installed actions without
@@ -739,7 +767,9 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
 
       // The hot fiber is gone: a fresh settings mount takes a fresh inventory
       // snapshot (the tab's list() runs per mount), which no longer lists the
-      // entry. An anchor entry's phase dot proves the snapshot rendered.
+      // entry. What proves the snapshot rendered is `expandGlobalPlane`'s own
+      // postcondition, a visible card whose id carries the `include:` prefix,
+      // so the absence below is an absence and not an unrendered list.
       await dialog.locator('.VOzbGW_close').click()
       await app.getByRole('button', { name: '设置', exact: true }).click({ timeout: 15_000 })
       const dialog3 = app.getByRole('dialog', { name: '设置' })
@@ -747,7 +777,6 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await dialog3.getByRole('button', { name: '插件', exact: true }).click()
       await dialog3.getByRole('tab', { name: '插件列表' }).click()
       await expandGlobalPlane(dialog3)
-      await dialog3.locator('[data-state]').first().waitFor({ state: 'visible', timeout: 15_000 })
       expect(await dialog3.locator('[data-plugin-entry="include:typert-gateway:mkt-e2e-live"]').count()).toBe(0)
     },
     120_000,
@@ -800,6 +829,8 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
 
       // Nothing is live: a fresh settings mount takes a fresh inventory
       // snapshot, and the config fixture has no hot entry in it.
+      // `expandGlobalPlane`'s postcondition is again what separates that from
+      // a Loader plane that simply has not rendered.
       await dialog.locator('.VOzbGW_close').click()
       await app.getByRole('button', { name: '设置', exact: true }).click({ timeout: 15_000 })
       const dialog2 = app.getByRole('dialog', { name: '设置' })
@@ -807,7 +838,6 @@ describe.skipIf(!hasDsh || !hasChromium)('web full flow', () => {
       await dialog2.getByRole('button', { name: '插件', exact: true }).click()
       await dialog2.getByRole('tab', { name: '插件列表' }).click()
       await expandGlobalPlane(dialog2)
-      await dialog2.locator('[data-state]').first().waitFor({ state: 'visible', timeout: 15_000 })
       expect(await dialog2.locator('[data-plugin-entry="include:typert-gateway:mkt-e2e-config"]').count()).toBe(0)
     },
     120_000,

--- a/packages/dsh-plugin-shop/tests/fixtures/live-packages/dsh-shop-e2e-live/index.js
+++ b/packages/dsh-plugin-shop/tests/fixtures/live-packages/dsh-shop-e2e-live/index.js
@@ -10,8 +10,10 @@
 // what the loader actually mounted — lists this entry (id
 // `include:typert-gateway:mkt-e2e-live`: the shop mounts the hot tree from
 // its own ctx, a subtree of the gateway include, and the `mkt-` row id
-// survives at the end of the chain) tagged `data-kind="enabled"` (it was
-// `data-enabled="true"` before harness 0.1.2-rc.1) and phase active while
-// the fiber runs, and drops it once the shop's hot uninstall disposes the
-// fiber. The e2e asserts exactly that.
+// survives at the end of the chain) as enabled, with its root fiber in the
+// active phase, while the fiber runs, and drops it once the shop's hot
+// uninstall disposes the fiber. The e2e asserts exactly those two facts.
+// HOW it reads them out of the DOM is deliberately not restated here: the
+// harness has renamed that markup twice, this comment carried the dead
+// spelling through both, and web-full-flow.e2e.ts's contract header owns it.
 module.exports = { apply() {} }

--- a/packages/dsh-plugin-shop/tests/host/index.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/index.test.ts
@@ -254,7 +254,9 @@ describe('ShopGateway', () => {
   })
 
   it('loads silently when the harness satisfies every declared peer range', async () => {
-    // 0.1.2-rc.1 against ^0.1.1-rc.2 is what is installed today: silence.
+    // 0.1.5-rc.1 against ^0.1.1-rc.2 is what is installed today: silence.
+    // peers.test.ts's INSTALLED table is where that shape is measured and
+    // kept; this case only needs one row of it to reach the load path.
     const profileDir = mkdtempSync(join(TEMP_ROOT, 'dsh-peerversion-ok-'))
     writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: [] } } }))
     const warnings: string[] = []
@@ -262,7 +264,7 @@ describe('ShopGateway', () => {
     new ShopGateway(ctx, {
       profile: 'web', profileDir,
       peerRanges: { '@deepseek-ai/dsh-app-boot': '^0.1.1-rc.2' },
-      resolvePeerVersion: () => '0.1.2-rc.1',
+      resolvePeerVersion: () => '0.1.5-rc.1',
     })
     expect(warnings).toEqual([])
   })

--- a/packages/dsh-plugin-shop/tests/host/peers.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/peers.test.ts
@@ -222,16 +222,24 @@ const versions = (table: Record<string, string>): PeerVersionResolver =>
   spec => table[spec] ?? null
 
 describe('peerVersionMismatches', () => {
-  it('is silent for the versions installed today: 0.1.2-rc.1 against ^0.1.1-rc.2', () => {
-    // The real shape. The harness ships nothing but -rc versions, so strict
+  it('is silent for the versions installed today: 0.1.5-rc.1 against ^0.1.1-rc.2', () => {
+    // The real shape, re-measured 2026-09-10 against the harness npm calls
+    // `latest` — a bare `require` of each package out of the dsh tree, not a
+    // reading of this repo's lockfile (which pins the dev deps a line behind,
+    // deliberately). The harness ships nothing but -rc versions, so strict
     // semver calls every one of these a violation and this test is what fails
     // if the comparison ever regresses to strict mode.
+    //
+    // Every version here exists. The typert-protocol entry carries the same
+    // job the invented `0.1.9-rc.3` used to: it is a patch ABOVE the range's
+    // own floor (0.1.1-rc.2) within the same 0.1 line, which is the case
+    // includePrerelease exists to admit.
     expect(peerVersionMismatches(DECLARED, versions({
-      '@deepseek-ai/cordis': '4.0.1',
-      '@deepseek-ai/cordis-plugin-include': '1.0.6',
-      '@deepseek-ai/dsh-app-boot': '0.1.2-rc.1',
-      '@deepseek-ai/dsh-home-paths': '0.1.2-rc.1',
-      '@deepseek-ai/dsh-typert-protocol': '0.1.9-rc.3',
+      '@deepseek-ai/cordis': '4.0.2',
+      '@deepseek-ai/cordis-plugin-include': '1.0.7',
+      '@deepseek-ai/dsh-app-boot': '0.1.5-rc.1',
+      '@deepseek-ai/dsh-home-paths': '0.1.5-rc.1',
+      '@deepseek-ai/dsh-typert-protocol': '0.1.5-rc.1',
     }))).toEqual([])
   })
 

--- a/packages/dsh-plugin-shop/tests/host/peers.test.ts
+++ b/packages/dsh-plugin-shop/tests/host/peers.test.ts
@@ -216,30 +216,64 @@ const DECLARED: Record<string, string> = {
   '@deepseek-ai/dsh-typert-protocol': '^0.1.1-rc.2',
 }
 
+/** The versions those peers actually resolve at, re-measured 2026-09-10 by a
+ * bare `require` of each package out of the tree the harness npm calls
+ * `latest` — NOT a reading of this repo's lockfile, which pins the harness dev
+ * deps a line behind on purpose (`.github/workflows/plugin.yml` owns why).
+ *
+ * One table, used by every case that means "the real install". There were two
+ * the first time this moved, and only one of them was re-measured. */
+const INSTALLED: Record<string, string> = {
+  '@deepseek-ai/cordis': '4.0.2',
+  '@deepseek-ai/cordis-plugin-include': '1.0.7',
+  '@deepseek-ai/dsh-app-boot': '0.1.5-rc.1',
+  '@deepseek-ai/dsh-home-paths': '0.1.5-rc.1',
+  '@deepseek-ai/dsh-typert-protocol': '0.1.5-rc.1',
+}
+
 /** A resolver over a fixed table: a name the table does not carry yields no
  * version, which is the no-verdict signal (absence is not a violation). */
 const versions = (table: Record<string, string>): PeerVersionResolver =>
   spec => table[spec] ?? null
 
 describe('peerVersionMismatches', () => {
-  it('is silent for the versions installed today: 0.1.5-rc.1 against ^0.1.1-rc.2', () => {
-    // The real shape, re-measured 2026-09-10 against the harness npm calls
-    // `latest` — a bare `require` of each package out of the dsh tree, not a
-    // reading of this repo's lockfile (which pins the dev deps a line behind,
-    // deliberately). The harness ships nothing but -rc versions, so strict
-    // semver calls every one of these a violation and this test is what fails
-    // if the comparison ever regresses to strict mode.
+  it('is silent for the versions installed today', () => {
+    // The three harness rows are the discriminating ones: the harness ships
+    // nothing but -rc versions, so strict semver rejects all three against
+    // `^0.1.1-rc.2`, and this test is what fails if the comparison ever
+    // regresses to strict mode. The two cordis peers are plain releases that
+    // satisfy it either way — they are here because INSTALLED is the real
+    // shape, not because they carry a case of their own.
     //
-    // Every version here exists. The typert-protocol entry carries the same
-    // job the invented `0.1.9-rc.3` used to: it is a patch ABOVE the range's
-    // own floor (0.1.1-rc.2) within the same 0.1 line, which is the case
-    // includePrerelease exists to admit.
+    // Every version here exists, which is what makes it a measurement and
+    // also what makes it perishable: the two cases below carry the boundary
+    // and the moving-harness properties, so neither depends on what npm
+    // happens to be serving on the day someone re-measures this one.
+    expect(peerVersionMismatches(DECLARED, versions(INSTALLED))).toEqual([])
+  })
+
+  it('accepts a peer resolving at exactly its declared floor', () => {
+    // `^4.0.1` and `^1.0.6` are the only non-prerelease ranges DECLARED
+    // carries, and INSTALLED now sits one patch above both — so nothing else
+    // in this file covers a found version EQUAL to its floor, the boundary a
+    // comparator regressed to an exclusive lower bound would break.
     expect(peerVersionMismatches(DECLARED, versions({
-      '@deepseek-ai/cordis': '4.0.2',
-      '@deepseek-ai/cordis-plugin-include': '1.0.7',
-      '@deepseek-ai/dsh-app-boot': '0.1.5-rc.1',
-      '@deepseek-ai/dsh-home-paths': '0.1.5-rc.1',
-      '@deepseek-ai/dsh-typert-protocol': '0.1.5-rc.1',
+      ...INSTALLED,
+      '@deepseek-ai/cordis': '4.0.1',
+      '@deepseek-ai/cordis-plugin-include': '1.0.6',
+    }))).toEqual([])
+  })
+
+  it('accepts an rc ahead of the installed one on the same minor line', () => {
+    // Deliberately hypothetical: `0.1.9-rc.3` is published nowhere and stands
+    // for whatever the next rc is. The harness moving forward underneath a
+    // fixed range is the event §7 of the harness-compatibility design doc
+    // (docs/design/2026-09-01-harness-compatibility.md) was written after, and
+    // it must not stop being covered every time INSTALLED is re-measured onto
+    // a single version.
+    expect(peerVersionMismatches(DECLARED, versions({
+      ...INSTALLED,
+      '@deepseek-ai/dsh-typert-protocol': '0.1.9-rc.3',
     }))).toEqual([])
   })
 
@@ -358,13 +392,7 @@ describe('createPeerVersionCheck', () => {
     const warnings: string[] = []
     createPeerVersionCheck({
       ranges: DECLARED,
-      resolve: versions({
-        '@deepseek-ai/cordis': '4.0.1',
-        '@deepseek-ai/cordis-plugin-include': '1.0.6',
-        '@deepseek-ai/dsh-app-boot': '0.1.2-rc.1',
-        '@deepseek-ai/dsh-home-paths': '0.1.2-rc.1',
-        '@deepseek-ai/dsh-typert-protocol': '0.1.2-rc.1',
-      }),
+      resolve: versions(INSTALLED),
       warn: message => warnings.push(message),
     })()
     expect(warnings).toEqual([])

--- a/registry/scripts/tests/repo-guards.test.ts
+++ b/registry/scripts/tests/repo-guards.test.ts
@@ -458,6 +458,35 @@ describe('what git is allowed to pick up', () => {
   })
 })
 
+describe('the harness pin and the e2e contract move together', () => {
+  it('names one harness version in plugin.yml and in the e2e contract header', () => {
+    // The e2e drives the real `dsh` on PATH, so a harness release can break it
+    // with nothing changed in this repository — and it has, twice: 0.1.2-rc.1
+    // split 插件列表 and collapsed the Loader plane, 0.1.5-rc.1 moved the
+    // enabled tag and the phase dot onto shared primitives. Both times the
+    // coupling between the pin and the selectors was a sentence in a comment,
+    // and both times it was discovered as an opaque timeout instead.
+    // The selectors themselves now read the accessibility contract rather than
+    // the design system's private data-*, which is what stops the NEXT rename
+    // from mattering; this guard is what stops the two files from disagreeing
+    // about which harness that contract was measured against.
+    const workflow = parse(read('.github/workflows/plugin.yml')) as {
+      jobs: Record<string, { steps: { run?: string }[] }>
+    }
+    const runs = (workflow.jobs.test?.steps ?? []).map(step => step.run ?? '')
+    const pinned = runs
+      .map(run => /npm install -g @deepseek-ai\/dsh@(\S+)/.exec(run)?.[1])
+      .find(version => version !== undefined)
+    expect(pinned, 'plugin.yml installs no pinned @deepseek-ai/dsh').toBeDefined()
+
+    const e2e = read('packages/dsh-plugin-shop/tests/client/web-full-flow.e2e.ts')
+    const declared = /Written against harness (\S+?) —/.exec(e2e)?.[1]
+    expect(declared, 'web-full-flow.e2e.ts declares no harness version').toBeDefined()
+    expect(declared, `plugin.yml pins ${pinned}, the e2e contract is written against ${declared}`)
+      .toBe(pinned)
+  })
+})
+
 describe('the exit criteria cannot skip silently in CI', () => {
   it('tells the package suite that a skipped exit criterion is a failure', () => {
     // real-install.test.ts and web-full-flow.e2e.ts are the P1 and P2 exit


### PR DESCRIPTION
## What broke

Two of `web-full-flow.e2e.ts`'s five cases time out against `dsh 0.1.5-rc.1`: the two that read the loader inventory. The other three pass, including the whole browse → install → §9.3 acknowledgement → failure-and-recovery flow — so the shop's own code is not the breakage. **This PR changes no product code.**

## Root cause

`data-kind` and `data-phase` no longer exist. `dsh-client-ui-settings-plugin-inventory` refactored `StateTag` and `PhaseDot` onto the shared `Tag` / `StateDot` primitives, and the hand-rolled spans those components used to render carried the attributes:

```diff
- StateTag: <span className="configTag" data-kind={kind}>{label}</span>
+ StateTag: <Tag tone={TAG_TONES[kind]}>{label}</Tag>

- PhaseDot: <span className="statusDot" data-phase={phase} role="img" aria-label={status} title={status} />
+ PhaseDot: <span className="phaseDot" role="img" aria-label={status} title={status}>
+             <StateDot state={PHASE_DOT_STATES[phase]} /></span>
```

The primitives carry the **mapped** value, so the same fact is still in the DOM under another name:

| assertion | 0.1.2-rc.1 | 0.1.5-rc.1 |
|---|---|---|
| the entry is enabled | `[data-kind="enabled"]` | `[data-tone="success"]` |
| its root fiber is active | `[data-phase="active"]` | `[data-state="done"]` |
| the snapshot rendered at all | `[data-phase]` | `[data-state]` |

Measured on `dsh-client-ui-settings-plugin-inventory`: `data-kind` 5 → 0, `data-phase` 4 → 0, every other `data-*` unchanged, and the entry card's own attributes byte-identical across the two versions.

**One trap for the next person:** both attributes now come from `dsh-client-ui-primitives`, which the web frontend *bundles* rather than installing as a package in the harness tree. A census of the inventory package alone says "the instrument was deleted"; the DOM still carries it.

## Why CI was green

`plugin.yml` pinned `0.1.2-rc.1`, whose inventory renders `data-kind` and has no `data-tone`. The pin and the selectors are mutually exclusive per harness version, which the pin's own comment already said:

> when this pin moves again, expect web-full-flow.e2e.ts to move with it

So the pin moves to `0.1.5-rc.1` — npm's `latest`, and what users install today — in the same commit, and its measured census table gains the row.

This is the second time these two cases have failed on a harness DOM change (the first was the collapsed Loader plane, H-10, 2026-09-03) for a different reason each time.

## Also

- `peers.test.ts`'s "the versions installed today" case named `0.1.2-rc.1` and carried an invented `0.1.9-rc.3`. Re-measured against the harness npm calls `latest`; every version now exists, and the typert-protocol entry keeps the discrimination that row existed for (a patch above the range floor).
- §7 of the harness-compatibility design dates its "installed now" row, which had drifted a second time.

## Verification

| check | result |
|---|---|
| `web-full-flow.e2e.ts` vs real `dsh 0.1.5-rc.1` + chromium | 5/5, 0 skipped |
| package suite | 784 passed |
| root suite | 1001 passed |
| `pnpm typecheck` | clean |

The hot-mount case goes from a 33.8 s timeout to passing in 6.2 s, and it asserts real liveness — the entry appears enabled and active in the loader inventory, then disappears on uninstall. Hot-mount is therefore **verified** on 0.1.5-rc.1, not merely un-broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
