### PR TITLE
ci(catalog): a test-only change no longer buys a fifty-minute harvest

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,13 +11,11 @@ on:
     # throttled the search endpoint, so the badge went red for reasons that
     # had nothing to do with the catalog. Only the inputs to the build
     # belong here — and the pipeline's own tests are not one of them.
-    # `registry/scripts/tests/**` sat inside `registry/**` and cost a full
-    # harvest on 2026-09-10, when a change to repo-guards.test.ts alone merged
-    # to main. Negations are read after the patterns above them, so the one
-    # below wins for that directory; repo-guards.test.ts keeps it pointed at
-    # whatever directory the root suite actually runs from, because a stale
-    # exclusion fails silently — it reverts to costing an hour per test edit
-    # rather than breaking anything a reader would notice.
+    # Negations are read after the patterns above them, so the one below wins
+    # for that directory. What it has to name, what it cost while it was
+    # missing, and how it fails once it goes stale are owned by
+    # repo-guards.test.ts, which folds this list the way GitHub does instead
+    # of looking a string up in it.
     paths: &catalog-inputs
       - 'registry/**'
       - '!registry/scripts/tests/**'
@@ -343,9 +341,9 @@ jobs:
           git diff --cached --quiet && exit 0
           # [skip ci]: this push carries REGISTRY_PUSH_TOKEN, and a PAT push
           # STARTS workflows where the checkout-persisted GITHUB_TOKEN it
-          # replaced did not. `push.paths` is registry/**, which is exactly
-          # what this commit touches, so without the marker every successful
-          # run triggers the next one — and it never converges, because
+          # replaced did not. `push.paths` covers the registry/ data this
+          # commit writes, so without the marker every successful run
+          # triggers the next one — and it never converges, because
           # repo-state.json re-fetches a rotating slice and always differs.
           git commit -m "chore(registry): llm classifier update [skip ci]"
           push_with_rebase "the classifier's output"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,9 +10,17 @@ on:
     # of README pushes fired seventeen harvests in a morning and npm
     # throttled the search endpoint, so the badge went red for reasons that
     # had nothing to do with the catalog. Only the inputs to the build
-    # belong here.
+    # belong here — and the pipeline's own tests are not one of them.
+    # `registry/scripts/tests/**` sat inside `registry/**` and cost a full
+    # harvest on 2026-09-10, when a change to repo-guards.test.ts alone merged
+    # to main. Negations are read after the patterns above them, so the one
+    # below wins for that directory; repo-guards.test.ts keeps it pointed at
+    # whatever directory the root suite actually runs from, because a stale
+    # exclusion fails silently — it reverts to costing an hour per test edit
+    # rather than breaking anything a reader would notice.
     paths: &catalog-inputs
       - 'registry/**'
+      - '!registry/scripts/tests/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -5,7 +5,8 @@ on:
     # The two root READMEs are here because a release commit moves all four
     # install pins together, and readme-pins.test.ts is the guard for exactly
     # that. Without them, a commit fixing only a root README triggers neither
-    # workflow: daily.yml filters on registry/** and the ROOT package.json.
+    # workflow: daily.yml filters on the catalog's inputs under registry/
+    # and the ROOT package.json.
     paths: &plugin-inputs
       - 'packages/dsh-plugin-shop/**'
       - 'packages/dsh-typert-protocol/**'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,13 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
+      # The root suite's own config and the typecheck's. daily.yml no longer
+      # triggers on the tests directory, so this leg is where both run for a
+      # test-only change — and a commit that moved the suite out from under
+      # that exclusion, by editing vitest.config.ts alone, used to start no
+      # workflow at all and so never ran the guard that watches for it.
+      - 'tsconfig.json'
+      - 'vitest.config.ts'
       - '.github/workflows/windows.yml'
   pull_request:
     paths: *windows-inputs
@@ -46,6 +53,15 @@ jobs:
       # The root suite (registry/scripts/tests/**) in full. Measured green on
       # Windows, and it is where the `import()` specifier bug lived.
       - run: pnpm test
+      # The ROOT typecheck, here and not only in daily.yml. tsconfig.json's
+      # include is `registry/scripts/**/*.ts`, tests included, and daily.yml
+      # is filtered off that directory — so for a test-only change this is the
+      # only `tsc --noEmit` in CI. vitest strips types without checking them,
+      # so without this step a `noUncheckedIndexedAccess` violation in a test
+      # file merges green and first fails the 03:17 cron at daily.yml's own
+      # typecheck, which runs BEFORE the harvest: no catalog, no publish and
+      # no Pages deploy that day, on a run whose diff contains nothing.
+      - run: pnpm typecheck
       # The package suite, whole, through the package's OWN `test` script —
       # `tsdown && tsdown -c tsdown.client.config.ts && vitest run`. The two
       # builds are load-bearing, not incidental: `apply.client.spec.tsx`

--- a/registry/scripts/tests/readme-pins.test.ts
+++ b/registry/scripts/tests/readme-pins.test.ts
@@ -87,9 +87,9 @@ describe('README install pins', () => {
     // ran on one: plugin.yml (which a release commit DOES trigger, because a
     // release moves packages/dsh-plugin-shop/package.json) ran only the
     // package suite, while daily.yml — the workflow that runs this file —
-    // filters on registry/** and the ROOT package.json, which a release
-    // commit does not touch. Drift was caught by the next scheduled build,
-    // after npm publish.
+    // filters on the catalog's inputs under registry/ and the ROOT
+    // package.json, which a release commit does not touch. Drift was
+    // caught by the next scheduled build, after npm publish.
     const plugin = readFileSync(join(repoRoot, '.github', 'workflows', 'plugin.yml'), 'utf8')
     expect(plugin, 'plugin.yml does not run the root suite').toMatch(/^\s+- run: pnpm test$/m)
     for (const readme of READMES) {

--- a/registry/scripts/tests/repo-guards.test.ts
+++ b/registry/scripts/tests/repo-guards.test.ts
@@ -85,6 +85,39 @@ describe('a path-filtered workflow watches its own file', () => {
   })
 })
 
+describe('a test-only change does not buy a harvest', () => {
+  it('excludes exactly the directory the root suite runs from', () => {
+    // daily.yml's paths start with `registry/**`, and the pipeline's own tests
+    // live under it, so editing one of them cost a full fifty-minute live
+    // harvest. Measured 2026-09-10: the merge of #39 carried
+    // registry/scripts/tests/repo-guards.test.ts and nothing else under
+    // registry/, and that was enough to start one; #40, which touched only
+    // plugin.yml, started none.
+    //
+    // The exclusion is correct only while it names the directory the root
+    // suite actually reads, so both halves are read from their owners rather
+    // than restated here — vitest.config.ts owns the include, daily.yml owns
+    // the paths. A stale exclusion fails SILENTLY: nothing breaks, test edits
+    // merely start costing an hour again, which no reader would notice. That
+    // is the whole reason this is worth guarding.
+    const daily = parse(read('.github/workflows/daily.yml')) as {
+      on?: { push?: { paths?: string[] } }
+      true?: { push?: { paths?: string[] } }
+    }
+    const paths = daily.on?.push?.paths ?? daily.true?.push?.paths ?? []
+    const block = /include:\s*\[([^\]]*)\]/.exec(read('vitest.config.ts'))?.[1]
+    const include = block === undefined ? undefined : /['"]([^'"]+)['"]/.exec(block)?.[1]
+    expect(include, 'vitest.config.ts declares no include to read').toBeDefined()
+    // `registry/scripts/tests/**/*.test.ts` -> `registry/scripts/tests`.
+    const suiteDir = include!.replace(/\/\*\*.*$/, '')
+    expect(suiteDir.length, `could not read a directory out of ${include}`).toBeGreaterThan(0)
+    expect(
+      paths,
+      `daily.yml does not exclude ${suiteDir}, so a test-only change costs a harvest`,
+    ).toContain(`!${suiteDir}/**`)
+  })
+})
+
 describe('the artifact round-trip is exercised where a dry run can see it', () => {
   const buildSteps = (): { name?: string; uses?: string; if?: string; with?: Record<string, string> }[] => {
     const workflow = parse(read('.github/workflows/daily.yml')) as {

--- a/registry/scripts/tests/repo-guards.test.ts
+++ b/registry/scripts/tests/repo-guards.test.ts
@@ -14,9 +14,20 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
+import vitestConfig from '../../../vitest.config.ts'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
 const read = (relative: string): string => readFileSync(join(repoRoot, relative), 'utf8')
+
+/** The `paths:` filter of one trigger of one workflow.
+ *
+ * YAML 1.1 reads a bare `on:` key as the boolean true, which is why the parsed
+ * object is checked under both spellings rather than one. */
+type Triggers = { push?: { paths?: string[] }; pull_request?: { paths?: string[] } }
+const triggerPaths = (file: string, event: 'push' | 'pull_request'): string[] | undefined => {
+  const parsed = parse(read(`.github/workflows/${file}`)) as { on?: Triggers; true?: Triggers }
+  return (parsed.on ?? parsed.true)?.[event]?.paths
+}
 
 describe('the catalog harvest is serialised across refs', () => {
   it('puts every pull-request run in ONE concurrency group', () => {
@@ -41,8 +52,8 @@ describe('the pipeline\'s own commits do not re-trigger the pipeline', () => {
   it('marks every commit the workflow pushes with [skip ci]', () => {
     // The build pushes with REGISTRY_PUSH_TOKEN, and a PAT push DOES start
     // workflows where the checkout-persisted GITHUB_TOKEN it replaced did not.
-    // `push.paths` is `registry/**`, which is exactly what these commits touch,
-    // so each successful run triggered the next one. It never converged either:
+    // `push.paths` covers the `registry/` data these commits write, so each
+    // successful run triggered the next one. It never converged either:
     // repo-state.json re-fetches a rotating REPO_BACKFILL_BUDGET slice, so
     // every run produces a diff and publish-catalog's "catalog unchanged"
     // skip can never fire. Measured on 2026-09-06: 28 catalog versions
@@ -72,13 +83,7 @@ describe('a path-filtered workflow watches its own file', () => {
     // carried packages/** files, which is a property of the BASE and not of
     // the change. daily.yml already lists itself; this makes that symmetric.
     for (const file of ['daily.yml', 'plugin.yml']) {
-      const on = (parse(read(`.github/workflows/${file}`)) as {
-        on?: { push?: { paths?: string[] } }
-        true?: { push?: { paths?: string[] } }
-      })
-      // YAML 1.1 reads a bare `on:` key as the boolean true, which is why the
-      // parsed object is checked under both spellings rather than one.
-      const paths = on.on?.push?.paths ?? on.true?.push?.paths
+      const paths = triggerPaths(file, 'push')
       expect(paths, `${file} declares no push.paths`).toBeDefined()
       expect(paths, `${file} does not watch itself`).toContain(`.github/workflows/${file}`)
     }
@@ -86,35 +91,143 @@ describe('a path-filtered workflow watches its own file', () => {
 })
 
 describe('a test-only change does not buy a harvest', () => {
-  it('excludes exactly the directory the root suite runs from', () => {
-    // daily.yml's paths start with `registry/**`, and the pipeline's own tests
-    // live under it, so editing one of them cost a full fifty-minute live
-    // harvest. Measured 2026-09-10: the merge of #39 carried
-    // registry/scripts/tests/repo-guards.test.ts and nothing else under
-    // registry/, and that was enough to start one; #40, which touched only
-    // plugin.yml, started none.
-    //
-    // The exclusion is correct only while it names the directory the root
-    // suite actually reads, so both halves are read from their owners rather
-    // than restated here — vitest.config.ts owns the include, daily.yml owns
-    // the paths. A stale exclusion fails SILENTLY: nothing breaks, test edits
-    // merely start costing an hour again, which no reader would notice. That
-    // is the whole reason this is worth guarding.
-    const daily = parse(read('.github/workflows/daily.yml')) as {
-      on?: { push?: { paths?: string[] } }
-      true?: { push?: { paths?: string[] } }
+  // daily.yml's paths start with `registry/**`, and the pipeline's own tests
+  // live under it, so editing one of them cost a full fifty-minute live
+  // harvest. Measured 2026-09-10: merging #39 to main started one, and
+  // registry/scripts/tests/repo-guards.test.ts was the only file it carried
+  // under registry/. #40 is no counter-example — rebasing it onto that merge
+  // started a catalog run of its own, though its entire diff was one file
+  // that is not a catalog input; a PR's filter decides on more than the diff
+  // its author wrote.
+  //
+  // A stale exclusion fails SILENTLY: nothing breaks, test edits merely start
+  // costing an hour again, which no reader would notice. That is the whole
+  // reason this is worth guarding — and why the guard EVALUATES the filter
+  // rather than reading a string out of it. GitHub tests a paths list in
+  // order and lets the last pattern that matches decide, so the presence of
+  // the `!` line is not the property that matters: lift it above
+  // `registry/**`, or add any matching positive pattern below it, and the
+  // directory is included again with the string still sitting in the list.
+
+  /** The subset of GitHub's filter-pattern syntax these workflows use: `**`
+   * spans path segments, `*` stays inside one, everything else is literal. */
+  const matcher = (pattern: string): RegExp =>
+    new RegExp(
+      `^${pattern.replace(/\*\*|\*|[.+?^${}()|[\]\\]/g, token =>
+        token === '**' ? '.*' : token === '*' ? '[^/]*' : `\\${token}`,
+      )}$`,
+    )
+
+  /** Whether `file` starts a trigger carrying `paths`, folded the way GitHub
+   * folds it: every pattern is tested in order, the last match decides, and a
+   * `!` pattern decides against. */
+  const starts = (paths: string[], file: string): boolean => {
+    let included = false
+    for (const pattern of paths) {
+      const negated = pattern.startsWith('!')
+      if (matcher(negated ? pattern.slice(1) : pattern).test(file)) included = !negated
     }
-    const paths = daily.on?.push?.paths ?? daily.true?.push?.paths ?? []
-    const block = /include:\s*\[([^\]]*)\]/.exec(read('vitest.config.ts'))?.[1]
-    const include = block === undefined ? undefined : /['"]([^'"]+)['"]/.exec(block)?.[1]
-    expect(include, 'vitest.config.ts declares no include to read').toBeDefined()
-    // `registry/scripts/tests/**/*.test.ts` -> `registry/scripts/tests`.
-    const suiteDir = include!.replace(/\/\*\*.*$/, '')
-    expect(suiteDir.length, `could not read a directory out of ${include}`).toBeGreaterThan(0)
+    return included
+  }
+
+  // The directories vitest runs the root suite from, imported from the config
+  // that owns them rather than restated here or scraped back out of its text:
+  // `registry/scripts/tests/**/*.test.ts` -> `registry/scripts/tests`. Every
+  // entry is read, because `include` is a list and a second suite root added
+  // to it would otherwise go unguarded.
+  const suites = (vitestConfig.test?.include ?? []).map(glob => ({
+    glob,
+    dir: glob.replace(/\/?\*.*$/, ''),
+  }))
+
+  // Every path-filtered workflow in the repository, so that "runs somewhere"
+  // below is a question asked of all of them rather than of a favourite.
+  const WORKFLOWS = ['daily.yml', 'plugin.yml', 'windows.yml']
+
+  // Files the build genuinely reads: a review file, the pipeline's source, the
+  // root manifest, the workflow itself. They are asserted from the same fold,
+  // so a negation wide enough to swallow them — `!registry/**` typed for
+  // `!registry/scripts/tests/**` — fails here instead of silently degrading
+  // the catalog to cron-only.
+  const CATALOG_INPUTS = [
+    'registry/verified.yml',
+    'registry/scripts/src/gate.ts',
+    'package.json',
+    '.github/workflows/daily.yml',
+  ]
+
+  it('leaves the root suite out of the catalog build, on both triggers', () => {
+    expect(suites, 'vitest.config.ts declares no include to read').not.toHaveLength(0)
+    for (const { glob, dir } of suites) {
+      expect(dir, `could not read a directory out of ${glob}`).not.toBe('')
+    }
+    // push and pull_request share one anchor today, and a PR run is the whole
+    // harvest as a dry run, so the half that is read cannot be assumed.
+    for (const event of ['push', 'pull_request'] as const) {
+      const paths = triggerPaths('daily.yml', event)
+      if (paths === undefined) throw new Error(`daily.yml declares no ${event}.paths`)
+      for (const { dir } of suites) {
+        for (const file of [`${dir}/probe.test.ts`, `${dir}/nested/probe.test.ts`]) {
+          expect(
+            starts(paths, file),
+            `daily.yml's ${event} filter matches ${file}, so a test-only change costs a harvest`,
+          ).toBe(false)
+        }
+      }
+      for (const input of CATALOG_INPUTS) {
+        expect(
+          starts(paths, input),
+          `daily.yml's ${event} filter no longer matches ${input}, so the catalog stopped building on its own input`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('keeps the suite, and the config that locates it, running somewhere', () => {
+    // The counterpart obligation: dropping a directory from the catalog build
+    // is only free while some workflow still runs it. windows.yml carries it
+    // through `registry/scripts/**` — and that workflow's own comment reasons
+    // about data-only churn under registry/, one narrowing away from leaving
+    // a test-only change with no CI at all. vitest.config.ts is here for the
+    // same reason one step out: this guard reads it, so the commit that moves
+    // the suite out from under the exclusion has to be one that runs it.
+    const watchedSomewhere = (file: string): boolean =>
+      WORKFLOWS.some(workflow => starts(triggerPaths(workflow, 'push') ?? [], file))
+    for (const { dir } of suites) {
+      expect(
+        watchedSomewhere(`${dir}/probe.test.ts`),
+        `no workflow runs on a change under ${dir}, so the suite guards nothing`,
+      ).toBe(true)
+    }
     expect(
-      paths,
-      `daily.yml does not exclude ${suiteDir}, so a test-only change costs a harvest`,
-    ).toContain(`!${suiteDir}/**`)
+      watchedSomewhere('vitest.config.ts'),
+      'no workflow runs on a change to vitest.config.ts, so this guard misses the commit that breaks it',
+    ).toBe(true)
+  })
+
+  it('still typechecks the suite it took out of the catalog build', () => {
+    // tsconfig.json's include is `registry/scripts/**/*.ts`, so the ROOT
+    // `tsc --noEmit` reads these tests — and it is the only thing that does:
+    // vitest strips types without checking them, and there is no hook, only a
+    // checkbox in the PR template. daily.yml ran that typecheck and no longer
+    // triggers here, so the leg that still triggers has to run it. Losing it
+    // fails the way this whole block is about: nothing goes red, a type error
+    // in a test file merges green, and the 03:17 cron dies on it before the
+    // harvest. The package's own `pnpm -C packages/... typecheck` is a
+    // different tsconfig and deliberately does not count.
+    const runsRootTypecheck = (workflow: string): boolean =>
+      /^\s+- run: pnpm typecheck$/m.test(read(`.github/workflows/${workflow}`))
+    for (const { dir } of suites) {
+      const covering = WORKFLOWS.filter(
+        workflow =>
+          starts(triggerPaths(workflow, 'push') ?? [], `${dir}/probe.test.ts`) &&
+          runsRootTypecheck(workflow),
+      )
+      expect(
+        covering,
+        `no workflow both triggers on ${dir} and runs the root typecheck`,
+      ).not.toHaveLength(0)
+    }
   })
 })
 
@@ -541,4 +654,3 @@ describe('the exit criteria cannot skip silently in CI', () => {
       .toBe('1')
   })
 })
-


### PR DESCRIPTION
## The cost

`daily.yml`'s paths start with `registry/**`, and the pipeline's own tests live under it. So editing one of them starts a full live harvest.

Measured 2026-09-10: the merge of #39 carried `registry/scripts/tests/repo-guards.test.ts` and **nothing else under `registry/`** — that alone was enough to start one.

The workflow's own comment already states the intent — "Only the inputs to the build belong here" — and a test file is not one. This makes the filter say what the comment says.

> **Correction.** An earlier revision of this description claimed #40 "started none" and offered it as the control. That is false: rebasing #40 onto #39's merge started a catalog run of its own at 16:04:28Z, though its entire diff is a single file that is not a catalog input. A PR's filter decides on more than the diff its author wrote, and a run cancelled by the concurrency group is easy to miss when scanning `gh run list` by conclusion. #40 is a second positive observation, not a control.

## The change

```yaml
paths: &catalog-inputs
  - 'registry/**'
  - '!registry/scripts/tests/**'
  - 'package.json'
  ...
```

Three things about it are load-bearing, and only the first is visible in the diff:

- **Order.** GitHub's documented rule: "A matching negative pattern (prefixed with `!`) after a positive match will exclude the path" — and, in the other direction, "a matching positive pattern after a negative match will include the path again." The negation is below `registry/**`, so it wins for that directory. This is now guarded rather than asserted; see below.
- **Quoting.** It must be `'!registry/scripts/tests/**'`. A bare `!` opens a YAML tag. Verified by parsing the file: the value arrives as a string, and `pull_request` shares `*catalog-inputs` so both triggers get it.
- **A positive neighbour.** A `!` pattern requires at least one non-`!` pattern beside it; five others are there.

## What the exclusion took with it

Filtering the directory out of `daily.yml` removed more than a harvest, and this is the half worth reading closely.

`pnpm typecheck` runs in **exactly one place** in CI — `daily.yml:114` — and `tsconfig.json`'s include is `registry/scripts/**/*.ts`, tests included. So excluding that directory left a test-only change with no `tsc --noEmit` anywhere. Proven rather than argued: a `noUncheckedIndexedAccess` violation dropped into a test file reports `1 passed` under vitest, which strips types without checking them, and `TS2322` under `tsc`.

The failure this produces is the shape this repository is least able to see: it merges green, then dies at the 03:17 cron on `daily.yml`'s own typecheck — a step that runs **before** the harvest, with `publish` and `deploy` both `needs: build`. A day with no catalog, no npm publish and no Pages deploy, attributed to a scheduled run whose diff contains nothing.

`windows.yml` is the only workflow a test-only change still starts, so it now runs the root typecheck too, and watches `tsconfig.json` and `vitest.config.ts`. That second path closes a blind spot this PR opened: the guard reads `vitest.config.ts`, which matched **no** workflow's filter — so the one commit shape that invalidates the exclusion, moving the suite include, started no CI at all and never ran the guard watching for it.

## The guard

Nothing restates the directory name. `vitest.config.ts` owns the include, `daily.yml` owns the paths, and `repo-guards.test.ts` reads both.

It **evaluates** the filter rather than looking a string up in it. `toContain` is a membership test, but GitHub folds a paths list in order and lets the last matching pattern decide — so lifting the `!` line above `registry/**`, or adding any matching positive pattern below it, re-includes the directory with the string still sitting in the list. The guard folds the list the way GitHub does, over **both** triggers rather than `push` alone: a PR run is the whole harvest as a dry run, and the two halves are one array only because a YAML anchor joins them today.

The same fold asserts that the catalog's real inputs still match, so a negation wide enough to swallow them fails loudly instead of silently degrading the build to cron-only. Two counterpart obligations are guarded rather than assumed: some workflow must still **run** the suite, and some workflow that triggers on it must run the **root** typecheck — the package's own `pnpm -C packages/... typecheck` is a different tsconfig and deliberately does not count.

A stale exclusion fails **silently** — nothing breaks, test edits merely start costing an hour again, which no reader would notice. That asymmetry is why it is worth a guard: this is a cost regression, not a correctness one.

## Verified by mutation

Eight edits that defeat the exclusion each turn the suite red:

| Mutation | Caught |
| --- | --- |
| negation lifted above `registry/**` | ✅ |
| `registry/scripts/**` added below the negation | ✅ |
| over-broad `!registry/**` | ✅ |
| anchor unrolled, `pull_request` keeps the old list | ✅ |
| `windows.yml` narrowed to `registry/scripts/src/**` | ✅ |
| `vitest.config.ts` dropped from `windows.yml` paths | ✅ |
| the typecheck step deleted from `windows.yml` | ✅ |
| a second suite root added to vitest's `include` | ✅ |

Two include shapes the previous regex mis-read are also fixed: `registry/scripts/tests/*.test.ts` (single star) used to derive a nonsense directory and produce a **false red**, and now derives correctly; a degenerate `**/*.test.ts` fails naming the glob rather than passing.

## What this PR cannot check about itself

That GitHub honours the negation. The YAML, the shared anchor and the guard are all checkable locally; the semantics are documented, and the first test-only commit to land on main without starting a run is what confirms them. Recorded rather than implied.

**This PR will itself start a catalog dry run** — it changes `daily.yml`, so it matches. That is correct, and worth saying so nobody reads it as the change failing.

## Verification

Root suite **1005 passed**, 33 files (1002 on main; +3 for the three guards). `pnpm typecheck` exit 0. On CI at `fb96c94`: `catalog`, `windows` ×2, `plugin` ×2 and GitGuardian all pass, with `publish` and `deploy` skipped as a PR dry run should. Confirmed from the logs rather than from the badge — `$ tsc --noEmit` executed on the Windows leg with step conclusion `success`, and `repo-guards.test.ts` ran **32 tests**.

## Not done here

`daily.yml` still gates one all-or-nothing filter over two workloads: ~2 minutes of `install`/`test`/`typecheck` and ~50 minutes of harvest in the same job. That coupling is *why* buying back the harvest cost the typecheck. Splitting them — a `verify` job, or a step-level `if:` on the harvest steps — would also make `package.json`, `pnpm-lock.yaml` and `registry/snapshots/**` free, each of which still buys a full harvest today. Left out deliberately: it is a change to which steps the filter governs, not to which directories it names, and it deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
